### PR TITLE
A rollup of changes after sync w/ G24 Hugo team

### DIFF
--- a/glasgow2024/templates/bits/convention_header.html
+++ b/glasgow2024/templates/bits/convention_header.html
@@ -36,7 +36,7 @@
                             <form method="post" action="{% url 'logout' %}">
                                 {% csrf_token %}
                                 <button class="btn btn-link" type="submit">
-                                    {% blocktranslate with user_name=user.first_name %}Sign Out {{ user_name }}{% endblocktranslate %}
+                                    {% blocktranslate with user_name=user.convention_profile.preferred_name %}Sign Out {{ user_name }}{% endblocktranslate %}
                                 </button>
                             </form>
                         </li>

--- a/nominate/admin.py
+++ b/nominate/admin.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import markdown
 from django.contrib import admin
-from django.db.models import ForeignKey
+from django.db.models import ForeignKey, QuerySet
 from django.forms import ModelChoiceField
 from django.http import HttpRequest
 from django.utils.safestring import mark_safe
@@ -16,9 +16,51 @@ class NominationAdminDataAdmin(admin.StackedInline):
     model = models.NominationAdminData
 
 
+@admin.action(description="Invalidate Selected Nominations")
+def invalidate_nomination(
+    modeladmin: admin.ModelAdmin, request: HttpRequest, queryset: QuerySet
+) -> None:
+    set_validation(queryset, False)
+
+
+@admin.action(description="Validate Selected Nominations")
+def validate_nomination(
+    modeladmin: admin.ModelAdmin, request: HttpRequest, queryset: QuerySet
+) -> None:
+    set_validation(queryset, True)
+
+
+def set_validation(queryset: QuerySet, valid: bool) -> None:
+    # update the ones that have admin data already
+    models.NominationAdminData.objects.filter(nomination__in=queryset).update(
+        valid_nomination=valid
+    )
+
+    # find the ones that don't already have info
+    nomination_without_admin = queryset.exclude(admin__isnull=False)
+
+    # create the missing ones
+    models.NominationAdminData.objects.bulk_create(
+        [
+            models.NominationAdminData(nomination=nomination, valid_nomination=valid)
+            for nomination in nomination_without_admin
+        ]
+    )
+
+
 class ExtendedNominationAdmin(admin.ModelAdmin):
     model = models.Nomination
     inlines = [NominationAdminDataAdmin]
+
+    list_display = ["__str__", "nomination_ip_address", "valid"]
+    actions = [invalidate_nomination, validate_nomination]
+
+    @admin.display(description="Valid?", boolean=True)
+    def valid(self, obj) -> bool:
+        try:
+            return obj.admin.valid_nomination
+        except models.NominationAdminData.DoesNotExist:
+            return True
 
 
 class VotingInformationAdmin(admin.StackedInline):

--- a/nominate/admin.py
+++ b/nominate/admin.py
@@ -146,3 +146,8 @@ admin.site.register(models.NominatingMemberProfile, NominatingMemberProfileAdmin
 admin.site.register(models.Category, CategoryAdmin)
 admin.site.register(models.Nomination, ExtendedNominationAdmin)
 admin.site.register(models.ReportRecipient, ReportRecipientAdmin)
+
+# Customize the Admin
+admin.site.site_title = "NomNom"
+admin.site.site_header = "NomNom Administration Interface"
+admin.site.index_title = "Hugo Administration"

--- a/nominate/admin.py
+++ b/nominate/admin.py
@@ -91,7 +91,7 @@ class ReportRecipientAdmin(admin.ModelAdmin):
 
 
 class NominatingMemberProfileAdmin(admin.ModelAdmin):
-    list_display = ["member_number", "name"]
+    list_display = ["member_number", "name", "preferred_name"]
 
     @admin.display()
     def name(self, obj):

--- a/nominate/apps.py
+++ b/nominate/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class NominateConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "nominate"
+
+    def ready(self) -> None:
+        from . import signals  # noqa: F401
+
+        return super().ready()

--- a/nominate/models.py
+++ b/nominate/models.py
@@ -236,6 +236,7 @@ class Category(models.Model):
 
     class Meta:
         verbose_name_plural = "categories"
+        ordering = ["ballot_position"]
 
 
 class Nomination(models.Model):

--- a/nominate/models.py
+++ b/nominate/models.py
@@ -224,12 +224,12 @@ class Category(models.Model):
     election = models.ForeignKey(Election, on_delete=models.PROTECT, null=True)
     name = models.CharField(max_length=100)
     description = models.TextField()
-    details = models.TextField()
+    details = models.TextField(blank=True)
     ballot_position = models.SmallIntegerField()
     fields = models.SmallIntegerField(default=1)
     field_1_description = models.CharField(max_length=100)
-    field_2_description = models.CharField(max_length=100, null=True)
-    field_3_description = models.CharField(max_length=100, null=True)
+    field_2_description = models.CharField(max_length=100, null=True, blank=True)
+    field_3_description = models.CharField(max_length=100, null=True, blank=True)
 
     def __str__(self):
         return self.name

--- a/nominate/signals.py
+++ b/nominate/signals.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.db.models.signals import m2m_changed
+from django.dispatch import receiver
+
+from nominate import admin
+from nominate.models import NominatingMemberProfile, Nomination
+
+
+@receiver(m2m_changed, sender=Group.user_set.through)
+def user_added_or_removed_from_group(sender, instance, action, pk_set, **kwargs):
+    if action == "post_remove":
+        try:
+            instance.convention_profile
+        except NominatingMemberProfile.DoesNotExist:
+            # no member for this, so we don't have nominations to remove
+            return
+
+        groups = Group.objects.filter(pk__in=pk_set)
+        if any(g.name == settings.NOMNOM_NOMINATING_GROUP for g in groups):
+            # we've removed the user from the nominating group; we are going to invalidate all the
+            # user's nominations now.
+            admin.set_validation(
+                Nomination.objects.filter(nominator=instance.convention_profile), False
+            )

--- a/nominate/templates/admin/nominate/election/change_form_object_tools.html
+++ b/nominate/templates/admin/nominate/election/change_form_object_tools.html
@@ -2,6 +2,9 @@
 {% block object-tools-items %}
     {{ block.super }}
     <li>
-        <a href="{% url "election:nomination-report" original.slug %}">Download the Nomination Report</a>
+        <a href="{% url "election:nomination-report" original.slug %}">Nominations Report</a>
+    </li>
+    <li>
+        <a href="{% url "election:invalidated-nomination-report" original.slug %}">Invalidated Nominations</a>
     </li>
 {% endblock object-tools-items %}

--- a/nominate/urls.py
+++ b/nominate/urls.py
@@ -25,4 +25,9 @@ urlpatterns = [
         reports.Nominations.as_view(),
         name="nomination-report",
     ),
+    path(
+        "e/<election_id>/invalidated-nominations/",
+        reports.InvalidatedNominations.as_view(),
+        name="invalidated-nomination-report",
+    ),
 ]

--- a/nominate/views.py
+++ b/nominate/views.py
@@ -147,6 +147,9 @@ class NominationView(NominatorView):
                     nomination_record.nominator = profile
                     nomination_record.nomination_ip_address = client_ip_address
                     nomination_record.save()
+
+                for deleted in formset.deleted_objects:
+                    deleted.delete()
             else:
                 had_errors = True
 

--- a/nomnom/settings.py
+++ b/nomnom/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 from pathlib import Path
 
+import bleach.sanitizer
 from django.utils.translation import gettext_lazy as _
 from environ import bool_var, config, group, to_config, var
 from icecream import install
@@ -295,6 +296,13 @@ CELERY_TIMEZONE = "America/Los_Angeles"
 CELERY_TASK_TRACK_STARTED = True
 CELERY_TASK_TIME_LIMIT = 30 * 60
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+
+# Presentation
+MARKDOWNIFY = {
+    "default": {
+        "WHITELIST_TAGS": bleach.sanitizer.ALLOWED_TAGS | {"p", "h4", "h5"},
+    }
+}
 
 # Email
 EMAIL_HOST = cfg.email.host

--- a/nomnom/settings.py
+++ b/nomnom/settings.py
@@ -55,6 +55,8 @@ class AppConfig:
     @config
     class CONVENTION:
         hugo_help_email = var("unset@nomnom.isntarealsite.com")
+        nominating_group = var("Nominator")
+        voting_group = var("Voter")
 
     debug = bool_var(default=False)
     db = group(DB)
@@ -147,6 +149,19 @@ INSTALLED_APPS = [
     ]
     if i
 ]
+
+# NomNom configuration
+NOMNOM_ALLOW_USERNAME_LOGIN_FOR_MEMBERS = cfg.allow_username_login
+
+# part of Six and Five
+NOMNOM_HUGO_NOMINATION_COUNT = 5
+
+# Convention information
+NOMNOM_CONVENTION_HUGO_HELP_EMAIL = cfg.convention.hugo_help_email
+
+NOMNOM_NOMINATING_GROUP = cfg.convention.nominating_group
+NOMNOM_VOTING_GROUP = cfg.convention.voting_group
+
 
 AUTHENTICATION_BACKENDS = [
     cfg.oauth.backend,
@@ -241,6 +256,8 @@ SOCIAL_AUTH_CLYDE_USER_FIELD_MAPPING = {
     "full_name": "first_name",
     "email": "email",
 }
+SOCIAL_AUTH_CLYDE_NOMINATING_GROUP = NOMNOM_NOMINATING_GROUP
+SOCIAL_AUTH_CLYDE_VOTING_GROUP = NOMNOM_VOTING_GROUP
 
 SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ["username", "first_name", "email"]
 
@@ -310,12 +327,3 @@ EMAIL_PORT = cfg.email.port
 EMAIL_HOST_USER = cfg.email.host_user
 EMAIL_HOST_PASSWORD = cfg.email.host_password
 EMAIL_USE_TLS = cfg.email.use_tls
-
-# NomNom configuration
-NOMNOM_ALLOW_USERNAME_LOGIN_FOR_MEMBERS = cfg.allow_username_login
-
-# part of Six and Five
-NOMNOM_HUGO_NOMINATION_COUNT = 5
-
-# Convention information
-NOMNOM_CONVENTION_HUGO_HELP_EMAIL = cfg.convention.hugo_help_email


### PR DESCRIPTION
- Allow blank nomination forms to remove the nomination. Fixes #33
- Invalidate nominations when a user's permissions are revoked. Fixes #34
- Add an invalidated nominations report
- Add bulk actions to toggle nomination validation: Fixes #35
- Display the preferred name everywhere. Fixes #31
- Fix the markdown to allow paragraphs. Fixes #38
- Allow blank values details and category fields. Fixes #37
- Order the category by its ballot position
- Nicer admin site changes
