### PR TITLE
Ensure that saving nominations is always consistent

### DIFF
--- a/nominate/forms.py
+++ b/nominate/forms.py
@@ -1,86 +1,114 @@
-from typing import Any, cast
+from itertools import groupby
+from operator import attrgetter
+from typing import Any
 
 from django import forms
 from django.conf import settings
-from django.forms.formsets import DELETION_FIELD_NAME
+from django.db import models
 from django.utils.translation import gettext as _
 
 from .models import Category, Finalist, Nomination, Rank
 
 
-class NominationForm(forms.ModelForm):
-    class Meta:
-        model = Nomination
-        fields = ["field_1", "field_2", "field_3"]
+class NominationForm(forms.BaseForm):
+    base_fields = []
 
-    def __init__(self, *args, **kwargs):
-        self.category = cast(Category, kwargs.pop("category"))
+    def __init__(
+        self,
+        *args,
+        categories: list[Category],
+        queryset: models.QuerySet | None = None,
+        **kwargs,
+    ):
+        self.categories = categories
+        if "initial" not in kwargs:
+            if queryset is not None:
+                kwargs["initial"] = self._data_from_queryset(queryset)
 
         super().__init__(*args, **kwargs)
 
-        field_descriptions = {
-            "field_1": self.category.field_1_description,
-            "field_2": self.category.field_2_description,
-            "field_3": self.category.field_3_description,
+        category_field_definitions: dict[str, models.CharField] = {
+            f.name: f
+            for f in Nomination._meta.get_fields()
+            if f.name.startswith("field_")
         }
 
-        fields_to_punt = self.Meta.fields[self.category.fields :]
+        fieldsets: dict[Category, list[list[forms.BoundField]]] = {}
+        self.fieldsets_grouped_by_category = fieldsets
 
-        for f in fields_to_punt:
-            self.fields.pop(f)
+        self.fields = {}
+        for category in self.categories:
+            field_descriptions = {
+                "field_1": category.field_1_description,
+                "field_2": category.field_2_description,
+                "field_3": category.field_3_description,
+            }
+            fieldset_list = fieldsets.setdefault(category, [])
+            for nomination_entry in range(settings.NOMNOM_HUGO_NOMINATION_COUNT):
+                fieldset = []
+                fieldset_list.append(fieldset)
 
-        # Update the form fields based on category.field_count
-        for i, field in enumerate(self.fields, start=1):
-            self.fields[field].label = field_descriptions[field]
-            self.fields[field].widget.attrs["placeholder"] = field_descriptions[field]
-            self.fields[field].widget.attrs["aria-label"] = field_descriptions[field]
+                for field_id in ["field_1", "field_2", "field_3"][0 : category.fields]:
+                    form_field_id = f"{category.id}-{nomination_entry}-{field_id}"
+                    kwargs = {
+                        "label": field_descriptions[field_id],
+                    }
+                    field = category_field_definitions[field_id].formfield(**kwargs)
+                    field.required = False
+                    self.fields[form_field_id] = field
 
-    @property
-    def nominating_fields(self) -> set[str]:
-        return set(self.Meta.fields[: self.category.fields])
+                    # we go into the __getitem__ here because this is how the fields are bound.
+                    # We could hack around this, but this way we're following the Django API.
+                    fieldset.append(self[form_field_id])
 
-    @property
-    def is_blank(self) -> bool:
-        data = [
-            bf.data
-            for name, bf in self._bound_items()
-            if name in self.nominating_fields
-        ]
-        return not any(data)
+    def _data_from_queryset(self, queryset: models.QuerySet) -> dict[str, Any]:
+        initial = {}
+        for category, nominations in groupby(
+            queryset.select_related("category").order_by("category"),
+            attrgetter("category"),
+        ):
+            for i, nomination in enumerate(nominations):
+                for field_id in ["field_1", "field_2", "field_3"][0 : category.fields]:
+                    field_name = f"{category.id}-{i}-{field_id}"
+                    initial[field_name] = getattr(nomination, field_id)
 
+        return initial
 
-class CustomBaseModelFormSet(forms.BaseModelFormSet):
-    def __init__(self, *args, **kwargs):
-        # We allow empty forms, because we use that to indicate deleted
-        kwargs["form_kwargs"]["empty_permitted"] = True
+    def clean(self) -> dict[str, Any]:
+        nominations: list[Nomination] = []
+        for category in self.categories:
+            fieldset_list = self.fieldsets_grouped_by_category[category]
+            for fieldset in fieldset_list:
+                # for each fieldset, either all fields are blank or none are blank
+                set_values = [bf.value() for bf in fieldset]
+                if all(set_values):
+                    # this is a valid nomination; add it to the set
+                    nomination_field_names = [bf.name.split("-")[-1] for bf in fieldset]
+                    nomination_values = [bf.value() for bf in fieldset]
+                    nomination_kwargs = dict(
+                        zip(nomination_field_names, nomination_values)
+                    )
+                    nominations.append(
+                        Nomination(category=category, **nomination_kwargs)
+                    )
+                    continue
 
-        self.category = kwargs["form_kwargs"]["category"]
-        super().__init__(*args, **kwargs)
+                if not any(set_values):
+                    # this is blank; no error here!
+                    continue
 
-    def _should_delete_form(self, form: NominationForm) -> bool:
-        # if the form's errors are _only_ for the text field, then we set _should_delete_form
-        if set(form.errors.keys()) == form.nominating_fields and form.is_blank:
-            return True
+                for bound_field in fieldset:
+                    if not bound_field.value():
+                        self.add_error(
+                            bound_field.name,
+                            forms.ValidationError(
+                                _("This field is required."),
+                                code="required",
+                                params={"required": True},
+                            ),
+                        )
 
-        return super()._should_delete_form(form)
-
-    def add_fields(self, form: forms.Form, index: int) -> None:
-        super().add_fields(form, index)
-
-        # we are, for our UI, deleting the boolean deletion field; that's not how we
-        # present this; we allow blank fields to delete.
-        if DELETION_FIELD_NAME in form.fields:
-            del form.fields[DELETION_FIELD_NAME]
-
-
-NominationFormset = forms.modelformset_factory(
-    Nomination,
-    form=NominationForm,
-    formset=CustomBaseModelFormSet,
-    can_delete=True,
-    extra=settings.NOMNOM_HUGO_NOMINATION_COUNT,
-    max_num=settings.NOMNOM_HUGO_NOMINATION_COUNT,
-)
+        self.cleaned_data["nominations"] = nominations
 
 
 class RankForm(forms.BaseForm):
@@ -100,7 +128,7 @@ class RankForm(forms.BaseForm):
                 self.ranks[rank.finalist] = rank.position
 
         super().__init__(*args, **kwargs)
-        self.fields_grouped_by_category = {}
+        self.fields_grouped_by_category: dict[Category, list[forms.BoundField]] = {}
         self.fields = {
             self.field_key(finalist): self.field_for_finalist(finalist)
             for finalist in self.finalists

--- a/nominate/renderers.py
+++ b/nominate/renderers.py
@@ -1,0 +1,12 @@
+from django_bootstrap5.renderers import FieldRenderer
+
+
+class BlankSafeFieldRenderer(FieldRenderer):
+    def get_server_side_validation_classes(self):
+        """Return CSS classes for server-side validation."""
+        if self.field_errors:
+            return "is-invalid"
+        elif self.field.form.is_bound:
+            if self.field.value():
+                return "is-valid"
+        return ""

--- a/nominate/templates/nominate/nominate.html
+++ b/nominate/templates/nominate/nominate.html
@@ -18,7 +18,8 @@
                 </div>
                 <form method="post">
                     {% csrf_token %}
-                    {% for category, formset in formsets.items %}
+                    {% for field in form.hidden_fields %}{{ field }}{% endfor %}
+                    {% for category, fieldset_list in form.fieldsets_grouped_by_category.items %}
                         <div class="container-fluid">
                             <fieldset>
                                 <legend>{{ category.name }}</legend>
@@ -28,16 +29,14 @@
                                         {{ category.nominating_details | markdownify }}
                                     </details>
                                 {% endif %}
-                                {{ formset.management_form }}
-                                {% for form in formset %}
+                                {% for fieldset in fieldset_list %}
                                     <div class="row">
-                                        {% for field in form.visible_fields %}
-                                            <div class="col">{% bootstrap_field field show_label=False success_css_class="has-error" %}</div>
+                                        {% for field in fieldset %}
+                                            <div class="col">{% bootstrap_field field show_label=False success_css_class="has-error" layout="blank-safe" %}</div>
                                         {% endfor %}
-                                        {% for field in form.hidden_fields %}{{ field }}{% endfor %}
                                     </div>
                                 {% endfor %}
-                                <button type="submit" class="btn btn-secondary" name="save_{{ category.id }}">Save this Category</button>
+                                <button type="submit" class="btn btn-secondary" name="save_all">Save as you go (saves all values)</button>
                             </fieldset>
                         </div>
                     {% endfor %}

--- a/nominate/tests/test_views.py
+++ b/nominate/tests/test_views.py
@@ -1,10 +1,11 @@
 from unittest.mock import Mock
 
 import pytest
-from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.models import AnonymousUser, Permission
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from model_bakery import baker
+from nominate import models
 from nominate.views import (
     ClosedElectionView,
     ElectionModeView,
@@ -87,7 +88,27 @@ class TestClosedElectionView(TestCase):
 
 class TestNominationView(TestCase):
     def setup_method(self, test_method):
+        self.election = baker.make("nominate.Election", state="nominating")
         self.request_factory = RequestFactory()
+        self.member = baker.make("nominate.NominatingMemberProfile")
+        self.user = self.member.user
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename="nominate", content_type__app_label="nominate"
+            )
+        )
+        self.c1 = baker.make(
+            "nominate.Category",
+            election=self.election,
+            fields=2,
+            ballot_position=1,
+        )
+        self.c2 = baker.make(
+            "nominate.Category",
+            election=self.election,
+            fields=2,
+            ballot_position=2,
+        )
 
     def test_get_anonymous(self):
         request = self.request_factory.get("/")
@@ -95,6 +116,116 @@ class TestNominationView(TestCase):
         response = NominationView.as_view()(request, election_id="dummy-election-id")
         assert response.status_code == 302
         assert response.url == f"{reverse('login')}?next=/"
+
+    def test_get_form(self):
+        request = self.request_factory.get("/")
+        request.user = self.user
+        response = NominationView.as_view()(request, election_id=self.election.slug)
+        assert response.status_code == 200
+
+    def submit_nominations(self, data):
+        url = reverse("election:nominate", kwargs={"election_id": self.election.slug})
+        self.client.force_login(self.user)
+        response = self.client.post(url, data=data)
+        return response
+
+    def test_submitting_valid_data_does_not_remove_other_nominations(self):
+        other_member = baker.make("nominate.NominatingMemberProfile")
+        baker.make(
+            "nominate.Nomination", category=self.c1, nominator=other_member, _quantity=2
+        )
+        assert models.Nomination.objects.count() == 2
+        valid_data = {
+            f"{self.c1.id}-0-field_1": "t1",
+            f"{self.c1.id}-0-field_2": "a1",
+        }
+        response = self.submit_nominations(valid_data)
+        assert response.status_code == 302
+        assert models.Nomination.objects.count() == 3
+
+    def test_submitting_invalid_data_does_not_save(self):
+        # Define your initial form data that is invalid
+        invalid_data = {
+            f"{self.c1.id}-0-field_1": "title 1",
+            f"{self.c1.id}-0-field_2": "",
+            f"{self.c1.id}-1-field_1": "title 2",
+            f"{self.c1.id}-1-field_2": "",
+            f"{self.c2.id}-0-field_1": "title 1",
+            f"{self.c2.id}-0-field_2": "",
+            f"{self.c2.id}-2-field_1": "title 3",
+            f"{self.c2.id}-2-field_2": "",
+        }
+        # Submit the form for the first time
+        response = self.submit_nominations(invalid_data)
+        assert response.status_code == 200
+        assert models.Nomination.objects.count() == 0
+
+    def test_submitting_invalid_data_is_nondestructive(self):
+        baker.make(
+            "nominate.Nomination",
+            category=iter([self.c1, self.c2]),
+            _quantity=2,
+        )
+        # Define your initial form data that is invalid
+        invalid_data = {
+            f"{self.c1.id}-0-field_1": "title 1",
+            f"{self.c1.id}-0-field_2": "",
+            f"{self.c1.id}-1-field_1": "title 2",
+            f"{self.c1.id}-1-field_2": "",
+            f"{self.c2.id}-0-field_1": "title 1",
+            f"{self.c2.id}-0-field_2": "",
+            f"{self.c2.id}-2-field_1": "title 3",
+            f"{self.c2.id}-2-field_2": "",
+        }
+        # Submit the form for the first time
+        response = self.submit_nominations(invalid_data)
+        assert response.status_code == 200
+        assert models.Nomination.objects.count() == 2
+
+    def test_series_of_submission_consistency(self):
+        # Define your initial form data that is invalid
+        invalid_data = {
+            f"{self.c1.id}-0-field_1": "novel title 1",
+            f"{self.c1.id}-0-field_2": "",
+            f"{self.c1.id}-1-field_1": "novel title 2",
+            f"{self.c1.id}-1-field_2": "",
+            f"{self.c2.id}-0-field_1": "novella title 1",
+            f"{self.c2.id}-0-field_2": "",
+            f"{self.c2.id}-2-field_1": "novella title 3",
+            f"{self.c2.id}-2-field_2": "",
+        }
+
+        # Submit the form for the first time
+        response = self.submit_nominations(invalid_data)
+        assert response.status_code == 200
+        assert models.Nomination.objects.count() == 0
+
+        # Modify invalid_data if necessary based on the response
+        invalid_data.update(
+            {
+                f"{self.c1.id}-0-field_2": "novel author 1",
+                f"{self.c1.id}-1-field_2": "novel author 2",
+            }
+        )
+
+        # Submit the form for the second time
+        response = self.submit_nominations(invalid_data)
+        assert response.status_code == 200
+        assert models.Nomination.objects.count() == 0
+
+        # Now define valid data, could be the modifications needed after two invalid attempts
+        valid_data = invalid_data.copy()  # Start with the last invalid data
+        valid_data.update(
+            {
+                f"{self.c2.id}-0-field_2": "novella author 1",
+                f"{self.c2.id}-2-field_2": "novella author 2",
+            }
+        )
+
+        # Submit the form for the third time, now with valid data
+        response = self.submit_nominations(valid_data)
+        assert response.status_code == 302
+        assert models.Nomination.objects.count() == 4
 
 
 class TestVoteView(TestCase):

--- a/nominate/views/nominate.py
+++ b/nominate/views/nominate.py
@@ -6,7 +6,7 @@ from django.utils.translation import gettext as _
 from ipware import get_client_ip
 
 from nominate import models
-from nominate.forms import NominationFormset
+from nominate.forms import NominationForm
 from nominate.tasks import send_ballot
 
 from .base import NominatorView
@@ -15,25 +15,18 @@ from .base import NominatorView
 class NominationView(NominatorView):
     template_name = "nominate/nominate.html"
 
-    def build_ballot_forms(self, data=None):
-        args = [] if data is None else [data]
-        return {
-            category: NominationFormset(
-                *args,
-                form_kwargs={"category": category},
-                queryset=models.Nomination.objects.filter(
-                    category=category, nominator=self.profile()
-                ),
-                prefix=str(category.id),
-            )
-            for category in self.categories()
-        }
-
     def get_context_data(self, **kwargs):
-        formsets = kwargs.pop("formsets", None)
-        if formsets is None:
-            formsets = self.build_ballot_forms()
-        ctx = {"formsets": formsets}
+        form = kwargs.pop("form", None)
+        if form is None:
+            form = NominationForm(
+                categories=list(self.categories()),
+                queryset=self.profile().nomination_set.filter(
+                    category__election=self.election()
+                ),
+            )
+        ctx = {
+            "form": form,
+        }
         ctx.update(super().get_context_data(**kwargs))
         return ctx
 
@@ -53,39 +46,28 @@ class NominationView(NominatorView):
             return redirect("election:index")
 
         profile = self.profile()
-        had_errors = False
         client_ip_address, _ = get_client_ip(request=request)
-        formsets = {
-            category: NominationFormset(
-                request.POST,
-                request.FILES,
-                form_kwargs={"category": category},
-                prefix=str(category.id),
-            )
-            for category in self.categories()
-        }
 
-        for category, formset in formsets.items():
-            if formset.is_valid():
-                for nomination_record in formset.save(commit=False):
-                    nomination_record.category = category
-                    nomination_record.nominator = profile
-                    nomination_record.nomination_ip_address = client_ip_address
-                    nomination_record.save()
+        form = NominationForm(categories=list(self.categories()), data=request.POST)
 
-                for deleted in formset.deleted_objects:
-                    deleted.delete()
-            else:
-                had_errors = True
+        if form.is_valid():
+            # first, we clear all of the existing nominations for this user and election; they've
+            # submitted a new ballot, so we're going to start from scratch.
 
-        if not had_errors:
+            # now, we're going to iterate through the formsets and save the nominations
+            for nomination in form.cleaned_data["nominations"]:
+                nomination.nominator = profile
+                nomination.ip_address = client_ip_address
+            models.Nomination.objects.bulk_create(form.cleaned_data["nominations"])
             messages.success(request, "Your set of nominations was saved")
+
             return redirect(
                 "election:nominate", election_id=self.kwargs.get("election_id")
             )
+
         else:
             messages.warning(request, "Something wasn't quite right with your ballot")
-            return self.render_to_response(self.get_context_data(formsets=formsets))
+            return self.render_to_response(self.get_context_data(form=form))
 
 
 class EmailNominations(NominatorView):

--- a/nomnom/settings.py
+++ b/nomnom/settings.py
@@ -345,6 +345,13 @@ MARKDOWNIFY = {
     }
 }
 
+BOOTSTRAP5 = {
+    "field_renderers": {
+        "default": "django_bootstrap5.renderers.FieldRenderer",
+        "blank-safe": "nominate.renderers.BlankSafeFieldRenderer",
+    },
+}
+
 # Email
 EMAIL_HOST = cfg.email.host
 EMAIL_PORT = cfg.email.port

--- a/scripts/bootstrap-codespaces.sh
+++ b/scripts/bootstrap-codespaces.sh
@@ -5,7 +5,7 @@ echo "deb [arch=all,$(dpkg --print-architecture) signed-by=/usr/share/keyrings/p
 
 sudo apt update
 
-sudo apt install just postgresql-client
+sudo apt -Y install just postgresql-client
 
 pipx install pdm
 


### PR DESCRIPTION
Fixes #62

This was a bit of a scary bug, in that it was possible for values in the
ballot to duplicate while saving the formsets.

Rather than do that, we now do this the slow, but very safe way; after
we've confirmed that our form is valid, we wipe out all of the user's
existing nominations, and then bulk save the new ones. This is
duplicative, but it's fast enough for our purposes, and guarantees we
don't need to worry about doubling the data.