### PR TITLE
Fix several issues with the ballot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This system doesn't have a version yet, so everything in here is listed under `1
 * Fixed a major inconsistency when saving nominations [#62, fixed in #67]
 * Submit ballots without losing one's place on the page [#73]
 * Ballot tweaks for voting [#121]
+* Ballot order respected for voting [#126]
 
 ### System Features
 

--- a/nominate/factories.py
+++ b/nominate/factories.py
@@ -43,6 +43,8 @@ class SingleFieldCategoryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Category
 
+    name = factory.Faker("sentence", nb_words=3)
+    description = factory.Faker("sentence", nb_words=10)
     election = factory.SubFactory(ElectionFactory)
     ballot_position = factory.Sequence(lambda n: n)
     fields = 1

--- a/nominate/forms.py
+++ b/nominate/forms.py
@@ -233,7 +233,10 @@ class RankForm(forms.BaseForm):
         # This is a view of the ranks by category excluding unranked. This is used to check for gaps.
         ranks_by_category: dict[Category, list[RankedFinalist]] = {}
         for finalist, rank in finalist_ranks.items():
-            if rank:
+            # only try this for actual ranks; invalid data in the rank field
+            # will be caught by the ChoiceField validation, but that happens
+            # after this step, regrettably.
+            if rank and str(rank).isdigit():
                 ranks_by_category.setdefault(finalist.category, []).append(
                     RankedFinalist(int(rank), finalist)
                 )

--- a/nominate/templates/nominate/voting_ballot_form.html
+++ b/nominate/templates/nominate/voting_ballot_form.html
@@ -4,7 +4,7 @@
 <form id="voting_ballot" method="post">
     {% csrf_token %}
     {% for field in form.hidden_fields %}{{ field }}{% endfor %}
-    {% for category, fields in form.fields_grouped_by_category.items %}
+    {% for category, fields in form.fields_grouped_by_category %}
         {% if forloop.first %}<div class="container-fluid">{% endif %}
             {% for field in fields %}
                 {% if forloop.first %}


### PR DESCRIPTION
- Fix #126 - sort the categories according to ballot order; this got lost in the
  group-by-categories step
- Fix #127 - block submitting a vote when the category has gaps.