### PR TITLE
Removing the download-the-whole-Packet option

### DIFF
--- a/glasgow2024/templates/hugopacket/bits/welcome.html
+++ b/glasgow2024/templates/hugopacket/bits/welcome.html
@@ -6,4 +6,4 @@
   <li>Download the materials for a specific Hugo Award category.</li>
 </ul>
 <p>We received no materials for the Best Dramatic Presentation, Short Form category, so there’s no download link for that category.</p>
-<p>Each category’s download includes a contents PDF with more information about the materials in that category.</p>
+<p>The download for each category includes a contents PDF with more information about the materials in that category. Almost every category includes material from all the finalists in the category, except for the following: Best Related Work (5 finalists included); Best Dramatic Presentation, Long Form (3 finalists); and Best Game (5 finalists).</p>

--- a/glasgow2024/templates/hugopacket/bits/welcome.html
+++ b/glasgow2024/templates/hugopacket/bits/welcome.html
@@ -2,8 +2,7 @@
 <p>The material in the Packet is provided only for the use of members of Glasgow 2024. Please don’t distribute Packet materials to others.</p>
 <p>You can download Packet materials in the following ways:</p>
 <ul>
-  <li>Download the entire Packet except for the Best Dramatic Presentation, Long Form category. (That category is a large download because it includes two full movies, so we’re providing an option to easily download the rest of the Packet.)</li>
-  <li>Download the entire Packet at once, including Best Dramatic Presentation, Long Form.</li>
+  <li>Download the entire Packet at once, except for the Best Dramatic Presentation, Long Form category. (That category is a large download because it includes two full movies.)</li>
   <li>Download the materials for a specific Hugo Award category.</li>
 </ul>
 <p>We received no materials for the Best Dramatic Presentation, Short Form category, so there’s no download link for that category.</p>

--- a/glasgow2024/templates/hugopacket/bits/welcome.html
+++ b/glasgow2024/templates/hugopacket/bits/welcome.html
@@ -1,5 +1,5 @@
 <p>Welcome to the 2024 Hugo Voter Packet!</p>
-<p>The material in the Packet is provided only for the use of members of Glasgow 2024. Please don’t distribute Packet materials to others.</p>
+<p>The material in the Packet is provided only for the use of members of Glasgow 2024. <strong>Please don’t distribute Packet materials to others.</strong></p>
 <p>You can download Packet materials in the following ways:</p>
 <ul>
   <li>Download the entire Packet at once, except for the Best Dramatic Presentation, Long Form category. (That category is a large download because it includes two full movies.)</li>

--- a/hugopacket/templates/hugopacket/index.html
+++ b/hugopacket/templates/hugopacket/index.html
@@ -13,7 +13,6 @@
                     </div>
                 {% endif %}
                 {% include "hugopacket/bits/welcome.html" %}
-                <p class="lead">The following packets are available for download:</p>
             </div>
         </div>
         {% for packet_file in packet_files %}


### PR DESCRIPTION
We’ve removed the link to download the whole Packet, so I’m removing that option from the instructions.