### PR TITLE
Permission removal uno reverse card

### DIFF
--- a/src/nomnom/nominate/models.py
+++ b/src/nomnom/nominate/models.py
@@ -1,5 +1,5 @@
-from datetime import UTC, datetime
 from collections.abc import Iterable
+from datetime import UTC, datetime
 
 from django.apps import apps
 from django.conf import settings
@@ -297,6 +297,15 @@ class Category(models.Model):
         ][: self.fields]
 
 
+class NominationValidManager(models.Manager):
+    def get_queryset(self) -> models.QuerySet:
+        return (
+            super()
+            .get_queryset()
+            .filter(Q(admin__valid_nomination=True) | Q(admin__isnull=True))
+        )
+
+
 class Nomination(models.Model):
     class Meta:
         permissions = [
@@ -348,6 +357,10 @@ class Nomination(models.Model):
 
     def __str__(self):
         return f"{self.category} by {self.nominator.display_name} on {self.nomination_date}"
+
+    # make sure we have the objects manager
+    objects = models.Manager()
+    valid = NominationValidManager()
 
 
 class NominationAdminData(models.Model):

--- a/src/nomnom/nominate/signals.py
+++ b/src/nomnom/nominate/signals.py
@@ -11,19 +11,32 @@ from nomnom.nominate.models import NominatingMemberProfile, Nomination
 @receiver(m2m_changed, sender=Group.user_set.through)
 def user_added_or_removed_from_group(sender, instance, action, pk_set, **kwargs):
     reverse = kwargs.get("reverse", False)
-    if action == "post_remove" and not reverse:
-        try:
-            instance.convention_profile
-        except NominatingMemberProfile.DoesNotExist:
-            # no member for this, so we don't have nominations to remove
-            return
-
-        groups = Group.objects.filter(pk__in=pk_set)
+    if action == "post_remove":
         convention_configuration = svcs_from().get(ConventionConfiguration)
+        nominating_group = convention_configuration.nominating_group
 
-        if any(g.name == convention_configuration.nominating_group for g in groups):
-            # we've removed the user from the nominating group; we are going to invalidate all the
-            # user's nominations now.
-            admin.set_validation(
-                Nomination.objects.filter(nominator=instance.convention_profile), False
-            )
+        if reverse:
+            # removing from the group side, we find the nominators via the PKs and clean those up
+            if instance.name == nominating_group:
+                nominators = NominatingMemberProfile.objects.filter(user__pk__in=pk_set)
+                admin.set_validation(
+                    Nomination.objects.filter(nominator__in=nominators),
+                    False,
+                )
+
+        else:
+            try:
+                instance.convention_profile
+            except NominatingMemberProfile.DoesNotExist:
+                # no member for this, so we don't have nominations to remove
+                return
+
+            groups = Group.objects.filter(pk__in=pk_set)
+
+            if any(g.name == nominating_group for g in groups):
+                # we've removed the user from the nominating group; we are going to invalidate all the
+                # user's nominations now.
+                admin.set_validation(
+                    Nomination.objects.filter(nominator=instance.convention_profile),
+                    False,
+                )

--- a/src/nomnom/nominate/signals.py
+++ b/src/nomnom/nominate/signals.py
@@ -10,7 +10,8 @@ from nomnom.nominate.models import NominatingMemberProfile, Nomination
 
 @receiver(m2m_changed, sender=Group.user_set.through)
 def user_added_or_removed_from_group(sender, instance, action, pk_set, **kwargs):
-    if action == "post_remove":
+    reverse = kwargs.get("reverse", False)
+    if action == "post_remove" and not reverse:
         try:
             instance.convention_profile
         except NominatingMemberProfile.DoesNotExist:

--- a/uv.lock
+++ b/uv.lock
@@ -1182,7 +1182,7 @@ wheels = [
 
 [[package]]
 name = "nomnom-hugoawards"
-version = "2025.0.0b7.dev12"
+version = "2025.0.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
We already had working removal of permissions to nominate when removing the group from the user, but not the user from the group

Do both, and test both.