### PR TITLE
Update docs for OSX devs

### DIFF
--- a/docs/docs/dev/index.md
+++ b/docs/docs/dev/index.md
@@ -15,7 +15,7 @@ The instructions here are for macOS; where appropriate, they'll proffer a Linux 
 
 #### Install your dependencies
 
-On macOS, that means installing copier, uv, and just. For simplicity these
+On macOS, that means installing copier, uv, just, and gsed. For simplicity these
 instructions will assume that you have homebrew installed, and follow the
 instructions to set your PATH for each tool.
 
@@ -30,6 +30,16 @@ instructions to set your PATH for each tool.
     $ brew install just
     $ just --version
     just 1.16.0
+    ```
+
+- [ ] gsed
+
+    gsed is required on MacOS to run several scripts that bootstrap the Python environment. Linux environments are fine with just sed.
+
+    ```shellsession
+    $ brew install gnu-sed
+    $ gsed --version
+    gsed (GNU sed) 4.9
     ```
 
 - [ ] Python


### PR DESCRIPTION
I ran into several gsed errors with running `just bootstrap` until I installed this extra dependency (on an M3 Mac, OS 14.6.1). I figured it might help other osx users to include this extra step :)