### PR TITLE
Add a cd step?

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -49,20 +49,22 @@ _message_after_copy: |
 
       brew install just
 
-  1. Set up your dependencies:
+  1. cd into the directory that you created.
+  
+  2. Set up your dependencies:
 
       uv venv
       uv sync
 
-  2. Configure your web application ports for local development. This is so that nomnom doesn't collide with any existing ports you use, but still offers local connections to the db and redis and webserver.
+  3. Configure your web application ports for local development. This is so that nomnom doesn't collide with any existing ports you use, but still offers local connections to the db and redis and webserver.
 
       scripts/get_web_port.sh
 
-  3. Commit the final template code to git, so you know where to start.
+  4. Commit the final template code to git, so you know where to start.
 
-  4. The .env file isn't set up with your local ports and credentials. Run this:
+  5. The .env file isn't set up with your local ports and credentials. Run this:
 
       just resetdb  # note -- this will DELETE ALL YOUR DEVELOPMENT DATA, skip it if you're not sure.
       just bootstrap
 
-  5. Once this is done, you can run the website using `just serve` and the email workers using `just worker`
+  6. Once this is done, you can run the website using `just serve` and the email workers using `just worker`


### PR DESCRIPTION
When I tried to run these setup steps in the main nomnom directory, there was no scripts/get_web_port.sh. I tried cd-ing to the new directory that I had made, and I could run scripts/get_web_port.sh from there. So I'm guessing that somewhere in these steps, the user needs to cd to that new directory. But if my proposed change here is wrong, let me know.