### PR TITLE
Create a development site

### DIFF
--- a/docs/docs/dev/bootstrap.md
+++ b/docs/docs/dev/bootstrap.md
@@ -1,0 +1,64 @@
+# Developer Environment Setup
+
+The instructions here are for macOS; where appropriate, they'll proffer a Linux equivalent.
+
+!!! info
+
+    Because I don't develop on Windows, I don't have equivalent instructions for setting up there. I would welcome Windows versions of these instructions!
+
+## Install your dependencies
+
+On macOS, that means installing the following:
+
+* Just
+* gsed
+* uv
+* Docker (with the compose addon)
+
+For simplicity, these instructions assume that you have Homebrew installed. After installing each tool,
+set your PATH appropriately as needed.
+
+- [ ] Just
+
+    [Just](https://just.systems/) is a task runner; it uses a Justfile to describe steps to run, and I
+    use it here to manage the setup and development processes.
+
+    Install it from your package manager:
+
+    ```shellsession
+    $ brew install just
+    $ just --version
+    just 1.16.0
+    ```
+
+- [ ] gsed
+
+    gsed is required on MacOS to run several scripts that bootstrap the Python environment. Linux environments are fine with just sed.
+
+    ```shellsession
+    $ brew install gnu-sed
+    $ gsed --version
+    gsed (GNU sed) 4.9
+    ```
+
+- [ ] uv
+
+    uv is a Python package and project manager.
+
+    ```shellsession
+    $ brew install uv
+    ... lots of output
+    $ uv -V
+    uv 0.6.6 (c1a0bb85e 2025-03-12)
+    ```
+
+- [ ] Docker compose
+
+    "Installing Docker" is beyond the scope of this document. You probably want [Docker Desktop](https://www.docker.com/products/docker-desktop/). Once it's installed and running, this should work:
+
+    ```shellsession
+    $ docker compose ps
+    NAME                IMAGE               COMMAND                  SERVICE             CREATED             STATUS              PORTS
+    ```
+
+    For most of the development process, Docker is only used to run the local PostgreSQL, Redis, and mailcatcher components used in testing and locally running the site.

--- a/docs/docs/dev/index.md
+++ b/docs/docs/dev/index.md
@@ -21,6 +21,8 @@ Option 1 is probably easiest, but option 2 gives you a slightly more faithful re
 
 ### Option 1: NomNomCon
 
+First, run the one-time setup steps; these only need to be done the first time you set this up, _or_ if you clean up the dev site:
+
 ```shellsession
 $ just dev-env
 $ just dev-bootstrap
@@ -34,10 +36,33 @@ uv run manage.py migrate
 DEBUG (0.001) CREATE EXTENSION IF NOT EXISTS pg_trgm;; args=None; alias=default
 
 ...much SQL and seeding follows
-$ just dev-serve
 ```
 
 Note that `dev-boostrap` will fail if run a second time; the seeds are not 100% idempotent.
+
+Now, you can run the server thusly:
+
+```shellsession
+$ just dev-serve
+```
+
+That will auto-reload changes as you make them, and reload your web views too, so you can iterate rapidly.
+
+To run the background worker, so that emailing will occur, you can run this:
+
+```shellsession
+$ just dev-worker
+```
+
+That does _not_ auto-reload; you will need to restart it when you make changes.
+
+If you want to have all of that done for you automatically, without needing to think about it, you can install the optional `overmind` and `entr` binaries, and then just run this:
+
+```shellsession
+overmind start
+```
+
+That'll run both the worker and the webserver, with restarts based on most code changes.
 
 
 ### Option 2: Generate a test convention

--- a/docs/docs/dev/index.md
+++ b/docs/docs/dev/index.md
@@ -9,70 +9,38 @@ Before you start working on NomNom, read some documents about the project:
 
 ## Making Changes
 
-The instructions here are for macOS; where appropriate, they'll proffer a Linux equivalent.
+First, [set up your developer environment](./bootstrap.md)
 
-!!! info
+From there you have two choices:
 
-    Because I don't develop on Windows, I don't have equivalent instructions for setting up there. I would welcome Windows versions of these instructions!
+1. Use the built in development convention. It is bare bones visually, but has all of the NomNom features enabled, and is ready to iterate on
 
-### Install your dependencies
+2. Create a test convention and work on that, using source links to integrate nomnom changes as you work.
 
-On macOS, that means installing the following:
+Option 1 is probably easiest, but option 2 gives you a slightly more faithful replica of a real convention instance.
 
-* Just
-* gsed
-* uv
-* Docker (with the compose addon)
+### Option 1: NomNomCon
 
-For simplicity, these instructions assume that you have Homebrew installed. After installing each tool,
-set your PATH appropriately as needed.
+```shellsession
+$ just dev-env
+$ just dev-bootstrap
+docker compose up --wait
+[+] Building 0.0s (0/0)                                                                   docker:orbstack
+[+] Running 3/3
+ ✔ Container nomnom-mailcatcher-1  Healthy                                                           0.0s
+ ✔ Container nomnom-redis-1        Healthy                                                           0.0s
+ ✔ Container nomnom-db-1           Healthy                                                           0.0s
+uv run manage.py migrate
+DEBUG (0.001) CREATE EXTENSION IF NOT EXISTS pg_trgm;; args=None; alias=default
 
-- [ ] Just
+...much SQL and seeding follows
+$ just dev-serve
+```
 
-    [Just](https://just.systems/) is a task runner; it uses a Justfile to describe steps to run, and I
-    use it here to manage the setup and development processes.
+Note that `dev-boostrap` will fail if run a second time; the seeds are not 100% idempotent.
 
-    Install it from your package manager:
 
-    ```shellsession
-    $ brew install just
-    $ just --version
-    just 1.16.0
-    ```
-
-- [ ] gsed
-
-    gsed is required on MacOS to run several scripts that bootstrap the Python environment. Linux environments are fine with just sed.
-
-    ```shellsession
-    $ brew install gnu-sed
-    $ gsed --version
-    gsed (GNU sed) 4.9
-    ```
-
-- [ ] uv
-
-    uv is a Python package and project manager.
-
-    ```shellsession
-    $ brew install uv
-    ... lots of output
-    $ uv -V
-    uv 0.6.6 (c1a0bb85e 2025-03-12)
-    ```
-
-- [ ] Docker compose
-
-    "Installing Docker" is beyond the scope of this document. You probably want [Docker Desktop](https://www.docker.com/products/docker-desktop/). Once it's installed and running, this should work:
-
-    ```shellsession
-    $ docker compose ps
-    NAME                IMAGE               COMMAND                  SERVICE             CREATED             STATUS              PORTS
-    ```
-
-    For most of the development process, Docker is only used to run the local PostgreSQL, Redis, and mailcatcher components used in testing and locally running the site.
-
-### Generate a test convention
+### Option 2: Generate a test convention
 
 Create a new directory to put your test convention in. It doesn't have to be inside your nomnom directory.
 

--- a/justfile
+++ b/justfile
@@ -87,6 +87,9 @@ dev-serve:
 dev-shell:
     uv run manage.py shell
 
+dev-mailcatcher:
+    open "http://localhost:$(docker compose port mailcatcher 1080 | cut -d: -f2)"
+
 docs-serve:
     uv run mkdocs serve -f docs/mkdocs.yml
 

--- a/justfile
+++ b/justfile
@@ -4,7 +4,6 @@ os := os()
 devcontainer := if env_var_or_default("USER", "nobody") == "vscode" {"true"} else {"false"}
 serve_host := if env_var_or_default("CODESPACES", "false") == "true" { "0.0.0.0" } else { "localhost" }
 
-export DJANGO_SETTINGS_MODULE := "nomnom_dev.settings"
 export DEV_SERVER_PORT := env_var_or_default("DEV_SERVER_PORT", "8000")
 
 default:
@@ -33,7 +32,7 @@ lint-fix:
     uv run ruff format
 
 test:
-    uv run pytest
+    uv run pytest -s
 
 dist:
     uvx --from build pyproject-build --installer uv
@@ -48,7 +47,17 @@ upload:
 docs:
     uv run mkdocs build -f docs/mkdocs.yml
 
-dev-bootstrap: dev-services dev-migrate dev-seed
+dev-bootstrap: dev-environment-check dev-services dev-migrate dev-seed
+
+dev-env:
+    scripts/setup-env.sh
+
+dev-environment-check:
+    #!/usr/bin/env bash
+    if [ ! -f .env ]; then
+        echo "No .env file found; the environment is not set up."
+        exit 1
+    fi
 
 dev-services:
     docker compose up --wait

--- a/manage.py
+++ b/manage.py
@@ -11,7 +11,7 @@ def main():
     All of the management commands in this application are intended to be
     run against the test settings. _Never_ use these in a production deployment of nomnom!
     """
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "nomnom.test_settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "nomnom_dev.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/nomnom_dev/services.py
+++ b/nomnom_dev/services.py
@@ -16,6 +16,8 @@ nomnom_convention = ConventionConfiguration(
     hugo_admin_email="nomnom-admin@example.com",
     registration_email="nomnom-reg@example.com",
     logo_alt_text="Nominate logo",
+    advisory_votes_enabled=True,
+    hugo_packet_backend="s3",
 )
 
 

--- a/nomnom_dev/settings.py
+++ b/nomnom_dev/settings.py
@@ -1,0 +1,388 @@
+# ruff: noqa: F401, E402
+"""
+Django settings for the NomNom test project.
+
+Manually maintained, similar to the settings.py.jinja2 template in convention-template.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/5.0/topics/settings/
+
+For the full list of settings and their values, see
+https://docs.djangoproject.com/en/5.0/ref/settings/
+
+To enable this, set DJANGO_SETTINGS_MODULE=nomnom_dev.settings
+"""
+
+from pathlib import Path
+
+import bleach.sanitizer
+import djp
+
+# Build paths inside the project like this: BASE_DIR / 'subdir'.
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+# import the system configuration from the application
+from nomnom.convention import system_configuration as cfg
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = cfg.secret_key
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = cfg.debug
+TEMPLATE_DEBUG = cfg.debug
+
+
+class InvalidStringShowWarning(str):
+    def __mod__(self, other):
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.warning(
+            f"In template, undefined variable or unknown value for: '{other}'"
+        )
+        return ""
+
+    def __bool__(self):  # if using Python 2, use __nonzero__ instead
+        # make the template tag `default` use its fallback value
+        return False
+
+
+ALLOWED_HOSTS = cfg.allowed_hosts
+
+CSRF_TRUSTED_ORIGINS = [f"https://{h}" for h in ALLOWED_HOSTS] if ALLOWED_HOSTS else []
+
+# Application definition
+
+INSTALLED_APPS = [
+    "nomnom.apps.NomnomAdminConfig",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.humanize",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.sites",
+    # use whitenoise to serve static files, instead of django's builtin
+    "whitenoise.runserver_nostatic",
+    "django.contrib.staticfiles",
+    # deferred tasks
+    "django_celery_results",
+    "django_celery_beat",
+    # debug helper
+    "django_extensions",
+    "django_browser_reload",
+    # to render markdown to HTML in templates
+    "markdownify.apps.MarkdownifyConfig",
+    # OAuth login
+    "social_django",
+    # Admin filtering enhancements
+    "admin_auto_filters",
+    # Admin forms
+    "django_admin_action_forms",
+    # Admin audit logging
+    "logentry_admin",
+    # Theming
+    "django_bootstrap5",
+    "fontawesomefree",
+    # HTMX support
+    "django_htmx",
+    # A healthcheck
+    "watchman",
+    # Markdown field support
+    "markdownfield",
+    "nomnom.base",
+    # the convention theme; this MUST come before the nominate app, so that its templates can
+    # override the nominate ones.
+    "nomnom_dev",
+    # The nominating and voting app
+    "nomnom.nominate",
+    "nomnom.canonicalize",
+    # Advisory Votes
+    "nomnom.advise",
+    # The hugo packet app
+    "nomnom.hugopacket",
+]
+
+SITE_ID = 1
+
+NOMNOM_ALLOW_USERNAME_LOGIN_FOR_MEMBERS = cfg.allow_username_login
+
+AUTHENTICATION_BACKENDS = [
+    # NOTE: the nomnom.nominate.apps.AppConfig.ready() hook will install handlers in this, as the first
+    # set. Any handler in here will be superseded by those.
+    #
+    # Uncomment following if you want to access the admin
+    "django.contrib.auth.backends.ModelBackend",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_browser_reload.middleware.BrowserReloadMiddleware",
+    "social_django.middleware.SocialAuthExceptionMiddleware",
+    "django_htmx.middleware.HtmxMiddleware",
+    "nomnom.middleware.HtmxMessageMiddleware",
+]
+
+ROOT_URLCONF = "nomnom_dev.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "social_django.context_processors.backends",
+                "social_django.context_processors.login_redirect",
+                "nomnom.nominate.context_processors.site",
+                "nomnom.nominate.context_processors.inject_login_form",
+            ],
+            "string_if_invalid": InvalidStringShowWarning("%s"),
+        },
+    },
+]
+
+WSGI_APPLICATION = "nomnom_dev.wsgi.application"
+
+
+# Database
+# https://docs.djangoproject.com/en/5.0/ref/settings/#databases
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": cfg.db.name,
+        "USER": cfg.db.user,
+        "PASSWORD": cfg.db.password,
+        "HOST": cfg.db.host,
+        "PORT": str(cfg.db.port),
+    }
+}
+
+# reuse some of those DB connections
+if not DEBUG:
+    CONN_HEALTH_CHECKS = True
+    CONN_MAX_AGE = 600
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": f"redis://{cfg.redis.host}:{cfg.redis.port}",
+    },
+}
+
+# Password validation
+# https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
+]
+
+LOGOUT_REDIRECT_URL = "index"
+
+# we are using postgres, so this is recommended in the docs.
+SOCIAL_AUTH_JSONFIELD_ENABLED = True
+
+# If using social authentication, configure it here. See the social_django documentation for
+# details.
+
+# Common social auth settings
+# Can't use the backend-specific one because of https://github.com/python-social-auth/social-core/issues/875
+# SOCIAL_AUTH_CLYDE_LOGIN_ERROR_URL = "nominate:login_error"
+SOCIAL_AUTH_LOGIN_ERROR_URL = "election:login_error"
+
+SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ["username", "first_name", "email"]
+
+# This is a probably-okay social auth pipeline, but you may need to adjust it for your needs.
+# See the social_django documentation for details.
+SOCIAL_AUTH_PIPELINE = [
+    "social_core.pipeline.social_auth.social_details",
+    "social_core.pipeline.social_auth.social_uid",
+    "social_core.pipeline.social_auth.auth_allowed",
+    "social_core.pipeline.social_auth.social_user",
+    "social_core.pipeline.user.get_username",
+    "social_core.pipeline.user.create_user",
+    "social_core.pipeline.social_auth.associate_user",
+    "social_core.pipeline.social_auth.load_extra_data",
+    "social_core.pipeline.user.user_details",
+    "nomnom.nominate.social_auth.pipeline.get_wsfs_permissions",
+    "nomnom.nominate.social_auth.pipeline.set_user_wsfs_membership",
+    "nomnom.nominate.social_auth.pipeline.normalize_date_fields",
+    "nomnom.nominate.social_auth.pipeline.restrict_wsfs_permissions_by_date",
+    "nomnom.nominate.social_auth.pipeline.add_election_permissions",
+]
+# Internationalization
+# https://docs.djangoproject.com/en/5.0/topics/i18n/
+
+LANGUAGE_CODE = "en-us"
+
+TIME_ZONE = "UTC"
+
+USE_I18N = True
+
+USE_TZ = True
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+USE_X_FORWARDED_PORT = True
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/5.0/howto/static-files/
+
+STATIC_URL = "static/"
+STATIC_ROOT = cfg.static_file_root
+
+# Default primary key field type
+# https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Async tasks
+CELERY_RESULT_BACKEND = "django-db"
+CELERY_CACHE_BACKEND = "default"
+CELERY_BROKER_URL = f"redis://{cfg.redis.host}:{cfg.redis.port}"
+CELERY_TIMEZONE = "America/Los_Angeles"
+CELERY_TASK_TRACK_STARTED = True
+CELERY_TASK_TIME_LIMIT = 30 * 60
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+
+# Presentation
+ADMIN_MANAGED_ATTRIBUTES = bleach.sanitizer.ALLOWED_ATTRIBUTES.copy()
+ADMIN_MANAGED_ATTRIBUTES.update(
+    {
+        "span": bleach.sanitizer.ALLOWED_ATTRIBUTES.get("span", []) + ["lang"],
+        "p": bleach.sanitizer.ALLOWED_ATTRIBUTES.get("p", []) + ["lang"],
+        "div": bleach.sanitizer.ALLOWED_ATTRIBUTES.get("div", []) + ["lang"],
+    }
+)
+ADMIN_ALERT_ATTRIBUTES = ADMIN_MANAGED_ATTRIBUTES.copy()
+ADMIN_ALERT_ATTRIBUTES["div"] += ["class", "role"]
+
+MARKDOWNIFY = {
+    "default": {
+        "WHITELIST_TAGS": bleach.sanitizer.ALLOWED_TAGS | {"p", "h4", "h5"},
+    },
+    "admin-content": {
+        "WHITELIST_TAGS": bleach.sanitizer.ALLOWED_TAGS | {"p", "h4", "h5", "span"},
+        "WHITELIST_ATTRS": ADMIN_MANAGED_ATTRIBUTES,
+    },
+    "admin-alert": {
+        "WHITELIST_TAGS": bleach.sanitizer.ALLOWED_TAGS
+        | {"p", "h4", "h5", "span", "div"},
+        "WHITELIST_ATTRS": ADMIN_ALERT_ATTRIBUTES,
+    },
+    "admin-label": {
+        # no block-level elements
+        "WHITELIST_TAGS": bleach.sanitizer.ALLOWED_TAGS
+        | {"span"} - {"blockquote", "ol", "li", "ul"},
+        "WHITELIST_ATTRS": ADMIN_MANAGED_ATTRIBUTES,
+    },
+}
+
+BOOTSTRAP5 = {
+    "field_renderers": {
+        "default": "django_bootstrap5.renderers.FieldRenderer",
+        "blank-safe": "nomnom.nominate.renderers.BlankSafeFieldRenderer",
+    },
+}
+
+# Email
+EMAIL_HOST = cfg.email.host
+EMAIL_PORT = cfg.email.port
+EMAIL_HOST_USER = cfg.email.host_user
+EMAIL_HOST_PASSWORD = cfg.email.host_password
+EMAIL_USE_TLS = cfg.email.use_tls
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "filters": {
+        "require_debug_true": {
+            "()": "django.utils.log.RequireDebugTrue",
+        },
+    },
+    "formatters": {
+        "verbose": {
+            "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
+            "style": "{",
+        },
+        "simple": {
+            "format": "{levelname} {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {
+            "level": "INFO",
+            "class": "logging.StreamHandler",
+            "formatter": "simple",
+        },
+        "debug_console": {
+            "level": "DEBUG",
+            "filters": ["require_debug_true"],
+            "class": "logging.StreamHandler",
+            "formatter": "simple",
+        },
+    },
+    "loggers": {
+        "django.db.backends": {
+            "level": "DEBUG",
+            "handlers": ["debug_console"],
+        },
+    },
+}
+
+
+# Sentry
+if cfg.sentry_sdk.dsn is not None:
+    # settings.py
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=cfg.sentry_sdk.dsn,
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        traces_sample_rate=1.0,
+        # Set profiles_sample_rate to 1.0 to profile 100%
+        # of sampled transactions.
+        # We recommend adjusting this value in production.
+        profiles_sample_rate=1.0,
+        # Our environment
+        environment=cfg.sentry_sdk.environment,
+        # include the user and client IP
+        send_default_pii=True,
+    )
+
+# Seed data can come from here:
+FIXTURE_DIRS = [BASE_DIR / "seed"]
+
+try:
+    from .settings_override import *  # noqa: F403
+except ImportError:
+    ...
+
+djp.settings(globals())

--- a/nomnom_dev/urls.py
+++ b/nomnom_dev/urls.py
@@ -1,0 +1,53 @@
+"""
+URL configuration for the NomNom test project.
+
+Manually maintained, similar to the urls.py.jinja2 template in convention-template.
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+https://docs.djangoproject.com/en/dev/topics/http/urls/
+Examples:
+Function views
+1. Add an import:  from my_app import views
+2. Add a URL to urlpatterns:  path('', views.home, name='home')
+Class-based views
+1. Add an import:  from other_app.views import Home
+2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
+Including another URLconf
+1. Import the include() function: from django.urls import include, path
+2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
+"""
+
+import djp
+from django.contrib import admin
+from django.urls import include, path
+from django_svcs.apps import svcs_from
+
+import nomnom.base.views
+from nomnom.convention import ConventionConfiguration
+
+convention_configuration = svcs_from().get(ConventionConfiguration)
+
+urlpatterns = [
+    path("", nomnom.base.views.index, name="index"),
+    path("e/", include("nomnom.nominate.urls", namespace="election")),
+    path("e/", include("nomnom.canonicalize.urls", namespace="canonicalize")),
+    # the below is omitted in the test app, since we don't have a convention
+    # app to customize. This file _is_ that app.
+    # path("convention/", include("nomnom_dev.urls", namespace="convention")),
+    path("admin/action-forms/", include("django_admin_action_forms.urls")),
+    path("admin/", admin.site.urls),
+    path("", include("social_django.urls", namespace="social")),
+    path("accounts/", include("django.contrib.auth.urls")),
+    path("watchman/", include("watchman.urls")),
+    path("__reload__/", include("django_browser_reload.urls")),
+] + djp.urlpatterns()
+
+if convention_configuration.hugo_packet_backend is not None:
+    urlpatterns.append(
+        path("p/", include("nomnom.hugopacket.urls", namespace="hugopacket")),
+    )
+
+if convention_configuration.advisory_votes_enabled:
+    urlpatterns.append(path("bm/", include("nomnom.advise.urls", namespace="advise")))
+
+handler403 = "nomnom.nominate.views.access_denied"

--- a/nomnom_dev/wsgi.py
+++ b/nomnom_dev/wsgi.py
@@ -1,0 +1,18 @@
+"""
+WSGI config for the NomNom test project.
+
+Manually maintained, similar to the wsgi.py.jinja2 template in convention-template.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/dev/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "nomnom_dev.settings")
+
+application = get_wsgi_application()

--- a/procfile
+++ b/procfile
@@ -1,0 +1,2 @@
+web: just dev-serve
+worker: fd | DJANGO_SETTINGS_MODULE=nomnom_dev.settings entr -nrz uv run celery -A nomnom worker -l INFO

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,15 +1,9 @@
 #!/bin/bash
-# A script to generate .env if it's not present using .env.sample as template
+set -eu -o pipefail
+# Set up the dev server environment. Uses the convention template's ensure_env.sh
+# script so that we're all on the same page.
 
-ENV_PATH=".env"
-SAMPLE_ENV_PATH=".env.sample"
+PROJECT_DIR=$(cd $(dirname "$0")/.. && pwd)
+cd "$PROJECT_DIR"
 
-if [ ! -f "$ENV_PATH" ]; then
-    while IFS= read -r line; do
-        processed_line=$(echo $line | perl -pe 's/\{\{(.+)\}\}/`$1`/ge')
-        echo "$processed_line" >> $ENV_PATH
-    done < "$SAMPLE_ENV_PATH"
-    echo "Generated .env file from sample."
-else
-    echo ".env file already exists."
-fi
+${PROJECT_DIR}/convention-template/scripts/ensure_env.sh

--- a/seed/all/0006_reports.json
+++ b/seed/all/0006_reports.json
@@ -1,0 +1,75 @@
+[
+    {
+        "model": "django_celery_beat.crontabschedule",
+        "pk": 1,
+        "fields": {
+            "minute": "4",
+            "hour": "2",
+            "day_of_month": "*",
+            "month_of_year": "*",
+            "day_of_week": "*",
+            "timezone": "America/Los_Angeles"
+        }
+    },
+    {
+        "model": "django_celery_beat.periodictasks",
+        "pk": 1,
+        "fields": { "last_update": "2025-04-27T17:44:42.213Z" }
+    },
+    {
+        "model": "django_celery_beat.periodictask",
+        "pk": 1,
+        "fields": {
+            "name": "Ranks Report",
+            "task": "nomnom.nominate.tasks.send_rank_report",
+            "interval": null,
+            "crontab": 1,
+            "solar": null,
+            "clocked": null,
+            "args": "[]",
+            "kwargs": "{}",
+            "queue": null,
+            "exchange": null,
+            "routing_key": null,
+            "headers": "{}",
+            "priority": null,
+            "expires": null,
+            "expire_seconds": null,
+            "one_off": false,
+            "start_time": null,
+            "enabled": false,
+            "last_run_at": null,
+            "total_run_count": 0,
+            "date_changed": "2025-04-27T17:44:01.381Z",
+            "description": "Send the rank report"
+        }
+    },
+    {
+        "model": "django_celery_beat.periodictask",
+        "pk": 2,
+        "fields": {
+            "name": "Nominations Report",
+            "task": "nomnom.nominate.tasks.send_nomination_report",
+            "interval": null,
+            "crontab": 1,
+            "solar": null,
+            "clocked": null,
+            "args": "[]",
+            "kwargs": "{}",
+            "queue": null,
+            "exchange": null,
+            "routing_key": null,
+            "headers": "{}",
+            "priority": null,
+            "expires": null,
+            "expire_seconds": null,
+            "one_off": false,
+            "start_time": null,
+            "enabled": false,
+            "last_run_at": null,
+            "total_run_count": 0,
+            "date_changed": "2025-04-27T17:44:42.210Z",
+            "description": "Send the daily nominations report"
+        }
+    }
+]

--- a/seed/dev/0007_packet.json
+++ b/seed/dev/0007_packet.json
@@ -1,0 +1,38 @@
+[
+    {
+        "model": "hugopacket.electionpacket",
+        "pk": 1,
+        "fields": {
+            "election": 2,
+            "name": "The PACKET",
+            "s3_bucket_name": "FIXME-nomnom-dev-bucket",
+            "enabled": true
+        }
+    },
+    {
+        "model": "hugopacket.packetfile",
+        "pk": 1,
+        "fields": {
+            "packet": 1,
+            "group": null,
+            "name": "File One",
+            "description": "File One Description",
+            "available": true,
+            "position": 0,
+            "s3_object_key": "file1"
+        }
+    },
+    {
+        "model": "hugopacket.packetfile",
+        "pk": 2,
+        "fields": {
+            "packet": 1,
+            "group": null,
+            "name": "File Two",
+            "description": "File Two description",
+            "available": true,
+            "position": 2,
+            "s3_object_key": "file2"
+        }
+    }
+]

--- a/seed/dev/0008_advise.json
+++ b/seed/dev/0008_advise.json
@@ -1,0 +1,13 @@
+[
+    {
+        "model": "advise.proposal",
+        "pk": 1,
+        "fields": {
+            "name": "OSS Only for the Hugos",
+            "full_text": "### 3.7.4 Nomination Software Licensing\r\n\r\nAll custom software used in the collection, processing, and reporting of member nominations for the Hugo Awards must be licensed under an Open Source Software (OSS) license, as defined by the Open Source Initiative (OSI). The license must be categorized as both “International” and “Popular” according to the OSI’s categorization scheme. The source code must be made available publicly to WSFS members before the close of nominations.\r\n\r\n### 3.11.6 Voting Software Licensing\r\n\r\nAll custom software used in the collection, processing, and reporting of member votes for the Hugo Awards must be licensed under an Open Source Software (OSS) license, as defined by the Open Source Initiative (OSI). The license must be categorized as both “International” and “Popular” according to the OSI’s categorization scheme. The source code must be made available publicly to WSFS members before the close of voting.",
+            "rendered_full_text": "<h3>3.7.4 Nomination Software Licensing</h3>\n<p>All custom software used in the collection, processing, and reporting of member nominations for the Hugo Awards must be licensed under an Open Source Software (OSS) license, as defined by the Open Source Initiative (OSI). The license must be categorized as both “International” and “Popular” according to the OSI’s categorization scheme. The source code must be made available publicly to WSFS members before the close of nominations.</p>\n<h3>3.11.6 Voting Software Licensing</h3>\n<p>All custom software used in the collection, processing, and reporting of member votes for the Hugo Awards must be licensed under an Open Source Software (OSS) license, as defined by the Open Source Initiative (OSI). The license must be categorized as both “International” and “Popular” according to the OSI’s categorization scheme. The source code must be made available publicly to WSFS members before the close of voting.</p>",
+            "state": "open",
+            "can_abstain": false
+        }
+    }
+]

--- a/src/nomnom/test_settings.py
+++ b/src/nomnom/test_settings.py
@@ -20,6 +20,7 @@ INSTALLED_APPS = [
     "nomnom_dev",
     "nomnom.nominate",
     "nomnom.advise",
+    "nomnom.hugopacket",
     "nomnom.canonicalize",
     "nplusone.ext.django",
 ]  # noqa: F405


### PR DESCRIPTION
This enables development without needing to create an entire convention;
it'll suffice, for example, for tuning the default templates, or for
working on ballot functionality.