### PR TITLE
Editorial updates

### DIFF
--- a/convention-template/config/settings.py.jinja
+++ b/convention-template/config/settings.py.jinja
@@ -98,7 +98,7 @@ INSTALLED_APPS = [
     "nomnom.nominate",
     "nomnom.canonicalize",
 {% if advisory_votes %}
-    # Advisory Votes
+    # Consultative Votes
     "nomnom.advise",
 {% endif %}
 {% if hugo_packet_enabled %}

--- a/docs/docs/admin/advisory_votes.md
+++ b/docs/docs/admin/advisory_votes.md
@@ -1,4 +1,4 @@
-# Advisory Votes
+# Consultative Votes
 
 This is an optional feature added to support Glasgow 2024's "Advisory Vote" concept.
 

--- a/src/nomnom/advise/templates/advise/index.html
+++ b/src/nomnom/advise/templates/advise/index.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% load nomnom_filters %}
+{% load i18n nomnom_filters %}
 {% block content %}
     <div class="container">
         {% if open_votes %}
             <div class="row">
-                <h1>Advisory Votes</h1>
+                <h1>{% translate "Consultative Votes" %}</h1>
             </div>
             {% for vote in open_votes %}
                 <div class="row">
@@ -26,7 +26,7 @@
         </div>
     {% else %}
         <div class="row">
-            <h1>There Are No Advisory Votes</h1>
+            <h1>There Are No Consultative Votes</h1>
         </div>
     {% endif %}
 {% endblock %}

--- a/src/nomnom/base/templates/nomnom/index.html
+++ b/src/nomnom/base/templates/nomnom/index.html
@@ -11,8 +11,8 @@
                     <!-- WSFS Elections Section for Mobile -->
                     <div class="p-5 text-center bg-body-tertiary">
                         <div class="container py-5">
-                            <h1 class="text-body-emphasis">{% translate "WSFS Elections" %}</h1>
-                            <p class="col-lg-8 mx-auto lead">{% translate "You can access your available WSFS elections here." %}</p>
+                            <h1 class="text-body-emphasis">{% translate "WSFS Voting Rights" %}</h1>
+                            <p class="col-lg-8 mx-auto lead">{% translate "The following voting opportunities are open to WSFS members." %}</p>
                         </div>
                     </div>
                     <div class="list-group justify-content-top mb-5">
@@ -20,11 +20,10 @@
                             {% include "nominate/_election_list_entry.html" with election=election %}
                         {% endfor %}
                     </div>
-
-                    <!-- Advisory Votes Section for Mobile -->
+                    <!-- Consultative Votes Section for Mobile -->
                     <div class="p-5 text-center bg-body-tertiary">
                         <div class="container py-5">
-                            <h1 class="text-body-emphasis">{% translate "Advisory Votes" %}</h1>
+                            <h1 class="text-body-emphasis">{% translate "Consultative Votes" %}</h1>
                         </div>
                     </div>
                     <div class="list-group justify-content-top">
@@ -50,7 +49,6 @@
                         {% endfor %}
                     </div>
                 </div>
-
                 <!-- For desktop: 2x2 grid layout -->
                 <div class="d-none d-md-block">
                     <!-- Headers Row -->
@@ -59,22 +57,20 @@
                         <div class="col-md-6">
                             <div class="p-5 text-center bg-body-tertiary">
                                 <div class="container py-5">
-                                    <h1 class="text-body-emphasis">{% translate "WSFS Elections" %}</h1>
-                                    <p class="col-lg-8 mx-auto lead">{% translate "You can access your available WSFS elections here." %}</p>
+                                    <h1 class="text-body-emphasis">{% translate "WSFS Voting Rights" %}</h1>
+                                    <p class="col-lg-8 mx-auto lead">{% translate "The following voting opportunities are open to WSFS members." %}</p>
                                 </div>
                             </div>
                         </div>
-
-                        <!-- Advisory Votes Header -->
+                        <!-- Consultative Votes Header -->
                         <div class="col-md-6">
                             <div class="p-5 text-center bg-body-tertiary">
                                 <div class="container py-5">
-                                    <h1 class="text-body-emphasis">{% translate "Advisory Votes" %}</h1>
+                                    <h1 class="text-body-emphasis">{% translate "Consultative Votes" %}</h1>
                                 </div>
                             </div>
                         </div>
                     </div>
-
                     <!-- Content Row -->
                     <div class="row">
                         <!-- WSFS Elections List -->
@@ -85,8 +81,7 @@
                                 {% endfor %}
                             </div>
                         </div>
-
-                        <!-- Advisory Votes List -->
+                        <!-- Consultative Votes List -->
                         <div class="col-md-6">
                             <div class="list-group justify-content-top">
                                 {% for proposal in proposals %}

--- a/src/nomnom/nominate/templates/bits/convention_header.html
+++ b/src/nomnom/nominate/templates/bits/convention_header.html
@@ -34,7 +34,7 @@
                 {% if ADVISORY_VOTES %}
                     <li class="nav-item">
                         <a class="nav-link" href="{% url 'advise:advisory_votes' %}">
-                            <span class="text-dark">{% translate "Advisory Votes" %}</span>
+                            <span class="text-dark">{% translate "Consultative Votes" %}</span>
                         </a>
                     </li>
                 {% endif %}

--- a/src/nomnom/nominate/templates/nominate/_election_list_entry.html
+++ b/src/nomnom/nominate/templates/nominate/_election_list_entry.html
@@ -22,7 +22,7 @@
             {% if election.packet_exists %}
                 <div class="d-grid pt-2">
                     {% if election.packet_is_ready %}
-                        <a href="{% url 'hugopacket:election_packet' election.slug %}">Download the Packet</a>
+                        <a href="{% url 'hugopacket:election_packet' election.slug %}">Download the Hugo Packet</a>
                     {% else %}
                         <p>The packet is not yet available</p>
                     {% endif %}


### PR DESCRIPTION
- Change "WSFS Elections" to "WSFS Voting Rights"
- Change "You can access your available WSFS elections here" to "The following voting opportunities are open to WSFS members"
- Change "Download the Packet" to "Download the Hugo Packet"
- Change "Advisory Votes" to "Consultative Votes"

Some of the proposed edits are elided because they are Seattle-specific
changes and these are generic nomnom edits.