### PR TITLE
run PR checks against PRs aimed at the year branches, too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI
 
 on:
   pull_request:
-    branches: ["main"]
+    branches:
+      - "main"
+      - "20*"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,8 @@ on:
       - "CODE_OF_CONDUCT.md"
   pull_request:
     branches:
-      - main
+      - "main"
+      - "20*"
     paths:
       - "docs/**/*"
       - ".github/workflows/docs.yml"

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -3,10 +3,14 @@ name: Template Check
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - "main"
+      - "20*"
     tags: ["*"]
   pull_request:
-    branches: ["main"]
+    branches:
+      - "main"
+      - "20*"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to include support for branches matching the pattern `20*`, in addition to the `main` branch. These changes ensure that workflows are triggered for versioned branches following a `20*` naming convention.

### Workflow updates to support additional branches:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL6-R8): Modified the `pull_request` trigger to include branches matching the `20*` pattern alongside `main`.
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cL14-R15): Updated the `pull_request` trigger to include branches matching the `20*` pattern for documentation-related changes.
* [`.github/workflows/template.yml`](diffhunk://#diff-8c756d76291b39cc76303be35bb3a526eae9d0b37c60fa60b1f444db109f7babL6-R13): Adjusted both `push` and `pull_request` triggers to support branches matching the `20*` pattern in addition to `main`.