### PR TITLE
When injecting the login form, use a less generic context variable name

### DIFF
--- a/convention-template/{{ app}}/templates/bits/login_forms.html
+++ b/convention-template/{{ app}}/templates/bits/login_forms.html
@@ -7,7 +7,7 @@
             <form method="POST"
                   action="{% url "login" %}?next={{ request.path }}"
                   accept-charset="UTF-8">
-                {% bootstrap_form form %}
+                {% bootstrap_form login_form %}
                 {% csrf_token %}
                 <div>
                     <input class="btn btn-primary login-btn" type="submit" value="Login">

--- a/src/nomnom/nominate/context_processors.py
+++ b/src/nomnom/nominate/context_processors.py
@@ -4,10 +4,10 @@ from urllib.parse import urlparse
 import django
 from django.conf import settings
 from django.templatetags.static import static
-
 from django_svcs.apps import svcs_from
-from nomnom.nominate import models
+
 from nomnom.convention import ConventionConfiguration
+from nomnom.nominate import models
 
 
 def site(request):
@@ -45,6 +45,6 @@ def url_or_static(url: str) -> str:
 
 def inject_login_form(request):
     if settings.NOMNOM_ALLOW_USERNAME_LOGIN_FOR_MEMBERS:
-        return {"form": django.contrib.auth.forms.AuthenticationForm()}
+        return {"login_form": django.contrib.auth.forms.AuthenticationForm()}
     else:
         return {}

--- a/src/nomnom/nominate/templates/bits/login_forms.html
+++ b/src/nomnom/nominate/templates/bits/login_forms.html
@@ -7,7 +7,7 @@
             <form method="POST"
                   action="{% url "login" %}?next={{ request.path }}"
                   accept-charset="UTF-8">
-                {% bootstrap_form form %}
+                {% bootstrap_form login_form %}
                 {% csrf_token %}
                 <div>
                     <input class="btn btn-primary login-btn" type="submit" value="Login">


### PR DESCRIPTION
Using `form` as the injected context name for the login form results in masking other `form` values added to the stacked context, which is the cause of https://github.com/LAConOrg/lacon-v/issues/8

- inject `login_form` instead of `form` in the login form context processor
- update login form templates to use the updated context variable

Fixes https://github.com/LAConOrg/lacon-v/issues/8