### PR TITLE
Template tag fixups and testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "django-admin-action-forms~=2.0",
     "django-google-fonts>=0.0.3",
     "django-bootstrap-static>=5.3.3",
+    "inflect>=7.5.0",
 ]
 requires-python = ">=3.12.0,<3.14"
 readme = "README.md"

--- a/src/nomnom/nominate/templatetags/nomnom_filters.py
+++ b/src/nomnom/nominate/templatetags/nomnom_filters.py
@@ -1,3 +1,4 @@
+import inflect
 from bs4 import BeautifulSoup
 from django import template
 from django.core.exceptions import ObjectDoesNotExist
@@ -23,18 +24,14 @@ def get_item(dictionary, key):
 @register.filter(name="user_display_name")
 def user_display_name(user):
     try:
-        return user.profile.display_name or user.email
+        return user.convention_profile.display_name or user.email
     except (AttributeError, ObjectDoesNotExist):
         return user.email
 
 
+p = inflect.engine()
+
+
 @register.filter(name="place")
 def place(value):
-    if value in (1, 21, 31):
-        return f"{value}st Place"
-    elif value in (2, 22):
-        return f"{value}nd Place"
-    elif value in (3, 23):
-        return f"{value}rd Place"
-    else:
-        return f"{value}th Place"
+    return f"{p.ordinal(value)} Place"

--- a/src/nomnom/nominate/tests/test_templatetags.py
+++ b/src/nomnom/nominate/tests/test_templatetags.py
@@ -1,0 +1,291 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from nomnom.nominate import factories
+from nomnom.nominate.templatetags.nomnom_filters import (
+    get_item,
+    html_text,
+    place,
+    user_display_name,
+)
+
+User = get_user_model()
+
+
+class TestStripHtmlTags:
+    """Tests for the strip_html_tags filter (html_text function)."""
+
+    def test_strips_simple_html_tags(self):
+        html = "<p>Hello World</p>"
+        result = html_text(html)
+        assert result == "Hello World"
+
+    def test_strips_multiple_tags(self):
+        html = "<div><p>Hello</p><span>World</span></div>"
+        result = html_text(html)
+        assert result == "Hello World"
+
+    def test_strips_nested_tags(self):
+        html = "<div><p><strong>Bold</strong> text</p></div>"
+        result = html_text(html)
+        assert result == "Bold text"
+
+    def test_handles_empty_string(self):
+        assert html_text("") == ""
+
+    def test_handles_none(self):
+        # Note: The function signature requires str, but template filters
+        # often receive None values in practice
+        assert html_text(None) == ""  # type: ignore[arg-type]
+
+    def test_preserves_text_without_tags(self):
+        text = "Plain text"
+        assert html_text(text) == text
+
+    def test_strips_tags_with_attributes(self):
+        html = '<p class="test" id="para">Text</p>'
+        result = html_text(html)
+        assert result == "Text"
+
+    def test_handles_self_closing_tags(self):
+        html = "<p>Line 1<br/>Line 2</p>"
+        result = html_text(html)
+        assert result == "Line 1 Line 2"
+
+    def test_handles_whitespace(self):
+        html = "<p>  Multiple   spaces  </p>"
+        result = html_text(html)
+        assert result == "Multiple   spaces"
+
+
+class TestGetItem:
+    """Tests for the get_item filter."""
+
+    def test_gets_existing_key(self):
+        dictionary = {"key": "value"}
+        assert get_item(dictionary, "key") == "value"
+
+    def test_returns_none_for_missing_key(self):
+        dictionary = {"key": "value"}
+        assert get_item(dictionary, "missing") is None
+
+    def test_handles_empty_dict(self):
+        assert get_item({}, "key") is None
+
+    def test_handles_numeric_keys(self):
+        dictionary = {1: "one", 2: "two"}
+        assert get_item(dictionary, 1) == "one"
+
+    def test_handles_nested_values(self):
+        dictionary = {"outer": {"inner": "value"}}
+        result = get_item(dictionary, "outer")
+        assert result == {"inner": "value"}
+
+
+@pytest.mark.django_db
+class TestUserDisplayName:
+    """Tests for the user_display_name filter.
+
+    The filter attempts to access user.profile.display_name, but the actual
+    related_name on the NominatingMemberProfile model is 'convention_profile'.
+    These tests expose this bug by asserting specific expected values.
+    """
+
+    @pytest.fixture
+    def user_without_profile(self):
+        """User with no associated profile."""
+        return factories.UserFactory.create(
+            email="noprofile@example.com", first_name="John", last_name="Doe"
+        )
+
+    @pytest.fixture
+    def user_with_preferred_name(self):
+        """User with profile that has a preferred_name set."""
+        user = factories.UserFactory.create(
+            email="preferred@example.com", first_name="Jane", last_name="Smith"
+        )
+        factories.NominatingMemberProfileFactory.create(
+            user=user, preferred_name="Preferred Display Name"
+        )
+        return user
+
+    @pytest.fixture
+    def user_with_empty_preferred_name(self):
+        """User with profile but preferred_name is empty string."""
+        user = factories.UserFactory.create(
+            email="empty@example.com", first_name="FirstName", last_name="LastName"
+        )
+        factories.NominatingMemberProfileFactory.create(user=user, preferred_name="")
+        return user
+
+    @pytest.fixture
+    def user_with_whitespace_preferred_name(self):
+        """User with profile but preferred_name is only whitespace."""
+        user = factories.UserFactory.create(
+            email="whitespace@example.com",
+            first_name="WhitespaceName",
+            last_name="User",
+        )
+        factories.NominatingMemberProfileFactory.create(user=user, preferred_name="   ")
+        return user
+
+    @pytest.fixture
+    def user_with_none_preferred_name(self):
+        """User with profile but preferred_name is None."""
+        user = factories.UserFactory.create(
+            email="null@example.com", first_name="NullName", last_name="User"
+        )
+        factories.NominatingMemberProfileFactory.create(user=user, preferred_name=None)
+        return user
+
+    @pytest.fixture
+    def user_without_first_name(self):
+        """User with profile but no first_name set."""
+        user = factories.UserFactory.create(
+            email="nofirstname@example.com", first_name="", last_name="LastName"
+        )
+        factories.NominatingMemberProfileFactory.create(user=user, preferred_name="")
+        return user
+
+    def test_returns_preferred_name_when_set(self, user_with_preferred_name):
+        """Should return preferred_name from profile.display_name."""
+        result = user_display_name(user_with_preferred_name)
+        # This test will FAIL because the filter looks for user.profile
+        # but the model uses related_name="convention_profile"
+        assert result == "Preferred Display Name", (
+            f"Expected preferred name, got {result!r}. "
+            "Filter may be catching AttributeError and falling back to email."
+        )
+
+    def test_returns_first_name_when_preferred_name_empty(
+        self, user_with_empty_preferred_name
+    ):
+        """Should return first_name when preferred_name is empty.
+
+        According to NominatingMemberProfile.display_name property:
+        - Returns preferred_name if it exists and is not just whitespace
+        - Otherwise returns user.first_name
+        """
+        result = user_display_name(user_with_empty_preferred_name)
+        assert result == "FirstName", (
+            f"Expected first name, got {result!r}. "
+            "When preferred_name is empty, display_name should return first_name."
+        )
+
+    def test_returns_first_name_when_preferred_name_whitespace(
+        self, user_with_whitespace_preferred_name
+    ):
+        """Should return first_name when preferred_name is only whitespace.
+
+        The display_name property uses .strip() to check for empty strings.
+        """
+        result = user_display_name(user_with_whitespace_preferred_name)
+        assert result == "WhitespaceName", (
+            f"Expected first name, got {result!r}. "
+            "Whitespace-only preferred_name should fall back to first_name."
+        )
+
+    def test_returns_first_name_when_preferred_name_none(
+        self, user_with_none_preferred_name
+    ):
+        """Should return first_name when preferred_name is None."""
+        result = user_display_name(user_with_none_preferred_name)
+        assert result == "NullName", (
+            f"Expected first name, got {result!r}. "
+            "None preferred_name should fall back to first_name."
+        )
+
+    def test_returns_email_when_no_profile_exists(self, user_without_profile):
+        """Should return email when user has no profile at all.
+
+        This is the intended fallback behavior when profile doesn't exist.
+        """
+        result = user_display_name(user_without_profile)
+        assert result == "noprofile@example.com", (
+            f"Expected email as fallback, got {result!r}"
+        )
+
+    def test_returns_email_when_first_name_also_empty(self, user_without_first_name):
+        """Should return email when both preferred_name and first_name are empty.
+
+        This tests the ultimate fallback: when display_name returns empty string,
+        the filter should return email.
+        """
+        result = user_display_name(user_without_first_name)
+        # The filter has: return user.profile.display_name or user.email
+        # So if display_name is empty, it should return email
+        # BUT since user.profile doesn't exist, it will catch exception and return email
+        assert result == "nofirstname@example.com", (
+            f"Expected email as ultimate fallback, got {result!r}"
+        )
+
+    def test_proper_precedence_preferred_over_first_over_email(
+        self, user_with_preferred_name
+    ):
+        """Verifies the proper precedence: preferred_name > first_name > email."""
+        # This user has all three: preferred_name, first_name, and email
+        user = user_with_preferred_name
+
+        # Should return preferred name (highest priority)
+        result = user_display_name(user)
+        assert result == "Preferred Display Name", (
+            "Should prefer preferred_name over first_name and email"
+        )
+
+        # Not testing the fallback chain here since we can't easily
+        # modify the profile once created, but other tests cover those cases
+
+
+class TestPlace:
+    """Tests for the place filter."""
+
+    def test_first_place(self):
+        assert place(1) == "1st Place"
+
+    def test_second_place(self):
+        assert place(2) == "2nd Place"
+
+    def test_third_place(self):
+        assert place(3) == "3rd Place"
+
+    def test_fourth_place(self):
+        assert place(4) == "4th Place"
+
+    def test_tenth_place(self):
+        assert place(10) == "10th Place"
+
+    def test_eleventh_place(self):
+        assert place(11) == "11th Place"
+
+    def test_twelfth_place(self):
+        assert place(12) == "12th Place"
+
+    def test_thirteenth_place(self):
+        assert place(13) == "13th Place"
+
+    def test_twenty_first_place(self):
+        assert place(21) == "21st Place"
+
+    def test_twenty_second_place(self):
+        assert place(22) == "22nd Place"
+
+    def test_twenty_third_place(self):
+        assert place(23) == "23rd Place"
+
+    def test_twenty_fourth_place(self):
+        assert place(24) == "24th Place"
+
+    def test_thirty_first_place(self):
+        assert place(31) == "31st Place"
+
+    def test_thirty_second_place(self):
+        assert place(32) == "32nd Place"
+
+    def test_thirty_third_place(self):
+        assert place(33) == "33rd Place"
+
+    def test_hundredth_place(self):
+        assert place(100) == "100th Place"
+
+    def test_hundred_first_place(self):
+        assert place(101) == "101st Place"

--- a/uv.lock
+++ b/uv.lock
@@ -1081,6 +1081,19 @@ wheels = [
 ]
 
 [[package]]
+name = "inflect"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+    { name = "typeguard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1363,6 +1376,15 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
 name = "mypy-boto3-s3"
 version = "1.39.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1407,6 +1429,7 @@ dependencies = [
     { name = "environ-config" },
     { name = "flower" },
     { name = "fontawesomefree" },
+    { name = "inflect" },
     { name = "jinja2" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pyrankvote" },
@@ -1483,6 +1506,7 @@ requires-dist = [
     { name = "environ-config", specifier = "~=24.1" },
     { name = "flower", specifier = "~=2.0" },
     { name = "fontawesomefree", specifier = "~=6.5" },
+    { name = "inflect", specifier = ">=7.5.0" },
     { name = "jinja2", specifier = "~=3.1" },
     { name = "psycopg", extras = ["binary"] },
     { name = "pyrankvote", specifier = "~=2.0" },
@@ -2359,6 +2383,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "typeguard"
+version = "4.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/68/71c1a15b5f65f40e91b65da23b8224dad41349894535a97f63a52e462196/typeguard-4.4.4.tar.gz", hash = "sha256:3a7fd2dffb705d4d0efaed4306a704c89b9dee850b688f060a8b1615a79e5f74", size = 75203, upload-time = "2025-06-18T09:56:07.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/a9/e3aee762739c1d7528da1c3e06d518503f8b6c439c35549b53735ba52ead/typeguard-4.4.4-py3-none-any.whl", hash = "sha256:b5f562281b6bfa1f5492470464730ef001646128b180769880468bd84b68b09e", size = 34874, upload-time = "2025-06-18T09:56:05.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- switch to the `inflect` library for ordinals in the `place()` filter
- fix a bug accessing .profile incorrectly in the `preferred_name()` filter
- llm-generate some comprehensive tests for these

Fixes: https://github.com/lAConOrg/nomnom-lacon-v/issues/20