### PR TITLE
Fix notifications not showing

### DIFF
--- a/src/nomnom/base/templates/base.html
+++ b/src/nomnom/base/templates/base.html
@@ -12,7 +12,7 @@
             </title>
             {% htmx_script %}
             <link rel="icon" href="{% static 'images/nomnom-icon.png' %}" />
-            <script src="{% static 'js/toasts.js' %}"></script>
+            <script src="{% static 'js/toasts.js' %}" defer></script>
             <!-- Styles -->
             {% include "customize/convention_styles.html" %}
             <!-- GNU -->


### PR DESCRIPTION
Commit 3e65333c switched to using a helper to load in htmx locally rather than the CDN version. This also added in the `defer` keyword, which defers the loading of the script. This meant that `htmx` wasn't defined when toasts.js loaded, meaning it never ran the code to toggle the visibility of toasts.

This patch adds the `defer` keyword to toasts.js so it also loads later, after the htmx has loaded.

Fixes: https://github.com/WorldconVotingSystems/nomnom/issues/298