### PR TITLE
Save the nominations before sending the email

### DIFF
--- a/src/nomnom/nominate/templates/nominate/nominate.html
+++ b/src/nomnom/nominate/templates/nominate/nominate.html
@@ -10,31 +10,21 @@
         {% block email-control %}
             {# This block is for the mobile interfaces; it only shows in small viewports #}
             <div class="d-block d-md-none">
-                <form action="{% url 'election:email-my-nominations' election_id=election.slug %}"
-                      method="post">
-                    {% csrf_token %}
-                    <div class="d-grid d-md-flex col-9">
-                        <button hx-swap="none"
-                                hx-post="{% url 'election:email-my-nominations' election_id=election.slug %}"
-                                hx-trigger="click"
-                                type="submit"
-                                class="btn btn-primary">{% translate "Email my nominations to me" %}</button>
-                    </div>
-                </form>
+                <div class="d-grid d-md-flex col-9">
+                    <button type="submit"
+                            form="nominating_ballot"
+                            name="save_and_email"
+                            class="btn btn-primary">{% translate "Email my nominations to me" %}</button>
+                </div>
             </div>
             {# This block is for the web interface; it only shows in larger viewports #}
             <div class="sticky-top d-none d-md-inline-flex justify-content-end vote-email float-end">
-                <form action="{% url 'election:email-my-nominations' election_id=election.slug %}"
-                      method="post">
-                    {% csrf_token %}
-                    <div class="d-grid d-md-flex col-9">
-                        <button hx-swap="none"
-                                hx-post="{% url 'election:email-my-nominations' election_id=election.slug %}"
-                                hx-trigger="click"
-                                type="submit"
-                                class="btn btn-primary">{% translate "Email my nominations to me" %}</button>
-                    </div>
-                </form>
+                <div class="d-grid d-md-flex col-9">
+                    <button type="submit"
+                            form="nominating_ballot"
+                            name="save_and_email"
+                            class="btn btn-primary">{% translate "Email my nominations to me" %}</button>
+                </div>
             </div>
         {% endblock email-control %}
         <div class="d-flex justify-content-center h-100 pt-3 pt-md-0">

--- a/src/nomnom/nominate/urls.py
+++ b/src/nomnom/nominate/urls.py
@@ -65,11 +65,6 @@ urlpatterns = [
     ),
     # Email views. These trigger emails to be sent for the user.
     path(
-        "<election_id>/email-nominations/",
-        views.nominate.EmailNominations.as_view(),
-        name="email-my-nominations",
-    ),
-    path(
         "<election_id>/email-votes/",
         views.vote.EmailVotes.as_view(),
         name="email-my-votes",


### PR DESCRIPTION
Previously clicking the button to send the email wouldn't save first. This meant that if you filled out a bunch of nominations and clicked "email", you would get an email saying you had no nominations.

This patch changes the way the email buttons work to, rather than be in their own form, be a part of the regular form but chain a POST request if the regular form succeeds.

This does mean the user gets two toasts, one saying the nominations saved and the other that they were emailed. It would be nice if these were merged into one toast, but in lieu of that, being explicit that they were saved is probably good.

Fixes: https://github.com/LAConOrg/nomnom-lacon-v/issues/25