### PR TITLE
bugfix: update the canonicalization forms to use admin forms 2.0 semantics

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,6 +38,9 @@ lint-fix:
 test:
     uv run pytest
 
+watch:
+    uv run pytest --looponfail
+
 test-debug:
     uv run pytest -s -v
 

--- a/src/nomnom/nominate/admin.py
+++ b/src/nomnom/nominate/admin.py
@@ -20,7 +20,7 @@ from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.safestring import mark_safe
-from django_admin_action_forms import action_with_form
+from django_admin_action_forms import AdminActionFormsMixin, action_with_form
 from django_admin_action_forms.forms import ActionForm
 
 from nomnom.nominate.decorators import user_passes_test_or_forbidden
@@ -430,7 +430,7 @@ def reset_ranks(modeladmin, request, queryset, data):
         )
 
 
-class CategoryAdmin(admin.ModelAdmin):
+class CategoryAdmin(AdminActionFormsMixin, admin.ModelAdmin):
     model = models.Category
 
     list_display = ["election", "name", "ballot_position"]

--- a/uv.lock
+++ b/uv.lock
@@ -515,14 +515,14 @@ wheels = [
 
 [[package]]
 name = "django-admin-action-forms"
-version = "2.1.0"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/3a/4161ac1248c82824db8cd091e933e5d73a9b278e6e213be967c5fe66af0d/django_admin_action_forms-2.1.0.tar.gz", hash = "sha256:3f8452c9fcc1bc5afe5295cbb56dab31bedc6a3f50267ff125426f824a7299df", size = 30804, upload-time = "2025-04-29T01:48:21.589Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/22/ea5897b32c8c3042f242ba694a55f7380de5668e98d2b73d219636daa30c/django_admin_action_forms-2.2.1.tar.gz", hash = "sha256:94ff59964ece5d6b8d2c9c307f22837863be173e3fb64fdcd64d6f301e1d0c9d", size = 31457, upload-time = "2025-10-28T23:10:45.619Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/91/80877890df67a70d5b2a3bde79b256a9af210a064841f61ffccbe889e6ec/django_admin_action_forms-2.1.0-py3-none-any.whl", hash = "sha256:eff4bc988ef26b696e4ab84a4c174ef05ede00db8254cae06cbeb42a8b877d0f", size = 34072, upload-time = "2025-04-29T01:48:20.146Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/6e/daad0e2f943578a07ee358e80dda4a24f558e0954f5866956a44d8a789fe/django_admin_action_forms-2.2.1-py3-none-any.whl", hash = "sha256:597d20d36fcb6cfbb0b5e0ed83df0c9dbd5af6b225f7af24f5b96a2ed84d4d35", size = 34312, upload-time = "2025-10-28T23:10:41.622Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
the Hugo team noted a bug in canonicalization where the forms allowing selection of works were not showing.

This is due to the upgrade of the admin forms library making some non-obvious breaking changes. This PR brings those up to date.