### PR TITLE
dev: don't add all the detailed permissions to nominator and voter gr…

### DIFF
--- a/seed/all/0001_groups.json
+++ b/seed/all/0001_groups.json
@@ -413,10 +413,6 @@
       "name": "Nominator",
       "permissions": [
         ["nominate", "nominate", "election"],
-        ["add_nomination", "nominate", "nomination"],
-        ["change_nomination", "nominate", "nomination"],
-        ["delete_nomination", "nominate", "nomination"],
-        ["view_nomination", "nominate", "nomination"]
       ]
     }
   },
@@ -426,10 +422,6 @@
       "name": "Voter",
       "permissions": [
         ["vote", "nominate", "election"],
-        ["add_rank", "nominate", "rank"],
-        ["change_rank", "nominate", "rank"],
-        ["delete_rank", "nominate", "rank"],
-        ["view_rank", "nominate", "rank"]
       ]
     }
   },


### PR DESCRIPTION
…oups

Fixes #354

The default seeds are a risky set of permissions if a member gets staff access, since they were conferring read/write access to the nominations/ranks data by default.

Fixed for future uses.