### PR TITLE
dev: add django-debug-toolbar to the dev site settings

### DIFF
--- a/nomnom_dev/settings.py
+++ b/nomnom_dev/settings.py
@@ -96,6 +96,8 @@ INSTALLED_APPS = [
     # debug helper
     "django_extensions",
     "django_browser_reload",
+    # debugging
+    "debug_toolbar",
     # to render markdown to HTML in templates
     "markdownify.apps.MarkdownifyConfig",
     # OAuth login
@@ -146,6 +148,7 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 MIDDLEWARE = [
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -432,6 +435,8 @@ if cfg.debug:
 
 # Seed data can come from here:
 FIXTURE_DIRS = [BASE_DIR / "seed"]
+
+DEBUG_TOOLBAR_ENABLED = True
 
 try:
     from .settings_override import *  # noqa: F403

--- a/nomnom_dev/urls.py
+++ b/nomnom_dev/urls.py
@@ -18,6 +18,7 @@ Including another URLconf
 """
 
 import djp
+from debug_toolbar.toolbar import debug_toolbar_urls
 from django.contrib import admin
 from django.urls import include, path
 from django_svcs.apps import svcs_from
@@ -27,20 +28,24 @@ from nomnom.convention import ConventionConfiguration
 
 convention_configuration = svcs_from().get(ConventionConfiguration)
 
-urlpatterns = [
-    path("", nomnom.base.views.index, name="index"),
-    path("e/", include("nomnom.nominate.urls", namespace="election")),
-    path("e/", include("nomnom.canonicalize.urls", namespace="canonicalize")),
-    # the below is omitted in the test app, since we don't have a convention
-    # app to customize. This file _is_ that app.
-    # path("convention/", include("nomnom_dev.urls", namespace="convention")),
-    path("admin/action-forms/", include("django_admin_action_forms.urls")),
-    path("admin/", admin.site.urls),
-    path("", include("social_django.urls", namespace="social")),
-    path("accounts/", include("django.contrib.auth.urls")),
-    path("watchman/", include("watchman.urls")),
-    path("__reload__/", include("django_browser_reload.urls")),
-] + djp.urlpatterns()
+urlpatterns = (
+    [
+        path("", nomnom.base.views.index, name="index"),
+        path("e/", include("nomnom.nominate.urls", namespace="election")),
+        path("e/", include("nomnom.canonicalize.urls", namespace="canonicalize")),
+        # the below is omitted in the test app, since we don't have a convention
+        # app to customize. This file _is_ that app.
+        # path("convention/", include("nomnom_dev.urls", namespace="convention")),
+        path("admin/action-forms/", include("django_admin_action_forms.urls")),
+        path("admin/", admin.site.urls),
+        path("", include("social_django.urls", namespace="social")),
+        path("accounts/", include("django.contrib.auth.urls")),
+        path("watchman/", include("watchman.urls")),
+        path("__reload__/", include("django_browser_reload.urls")),
+    ]
+    + djp.urlpatterns()
+    + debug_toolbar_urls()
+)
 
 if convention_configuration.hugo_packet_backend is not None:
     urlpatterns.append(


### PR DESCRIPTION
What it says on the tin; this is useful when developing nomnom