### PR TITLE
nit: enforce that Works never have trailing whitespace

### DIFF
--- a/src/nomnom/canonicalize/models.py
+++ b/src/nomnom/canonicalize/models.py
@@ -30,6 +30,10 @@ class Work(models.Model):
     def election(self) -> "nominate.Election":
         return self.category.election
 
+    def save(self, *args, **kwargs):
+        self.name = self.name.strip()
+        super().save(*args, **kwargs)
+
     def __str__(self) -> str:
         return self.name
 


### PR DESCRIPTION
We saw issues with works not auto-linking because of this.