### PR TITLE
Add quick "Group works" button

### DIFF
--- a/src/nomnom/canonicalize/templates/admin/canonicalize/canonicalizednomination/actions.html
+++ b/src/nomnom/canonicalize/templates/admin/canonicalize/canonicalizednomination/actions.html
@@ -1,0 +1,19 @@
+{% extends "admin/actions.html" %}
+{% load i18n %}
+
+{# The hidden action input and index arithmetic below rely on there being exactly one
+   action bar (actions_on_top only, the default). The "Group Works" button submits
+   index=1 to make Django pick the second value in POST.getlist("action"), which is
+   the hidden "group_works" input. The "Go" button submits index=0, picking the
+   dropdown value as normal. Adding actions_on_bottom would break this. #}
+
+{% block actions-form %}
+  {{ block.super }}
+  <input type="hidden" name="action" value="group_works">
+{% endblock %}
+
+{% block actions-submit %}
+  <button type="submit" class="button" title="{% translate "Run the selected action" %}" name="index" value="{{ action_index|default:0 }}">{% translate "Go" %}</button>
+  <span aria-hidden="true">|</span>
+  <button type="submit" class="button" name="index" value="{{ action_index|default:0|add:1 }}">{% translate "Group Works" %}</button>
+{% endblock %}


### PR DESCRIPTION
This reduces the number of clicks needed to group works, which is a very common step in the canonicalization workflow.

<img width="2842" height="1784" alt="image" src="https://github.com/user-attachments/assets/2d33ef04-c165-4bae-8d14-5d93a1737384" />
