### PR TITLE
Streamline the canonicalize group workflow

### DIFF
--- a/src/nomnom/canonicalize/admin.py
+++ b/src/nomnom/canonicalize/admin.py
@@ -1,8 +1,6 @@
-import bisect
 import csv
 import functools
 import io
-from collections import Counter
 from collections.abc import Iterable
 from itertools import groupby
 from typing import Any
@@ -50,20 +48,50 @@ def remove_canonicalization(
 
 
 class GroupNominationsForm(AdminActionForm):
-    work = forms.ModelChoiceField(
+    template = "canonicalize/group_nominations_action_form.html"
+
+    work_selection = forms.CharField(required=True)
+    work_search = forms.ModelChoiceField(
         required=False,
         queryset=models.Work.objects.order_by("name"),
-        empty_label="Create New Work from Nominations",
-        help_text="Select an existing work to group these nominations into. Leave blank to create a new Work",
+        label="",
     )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
         self.__post_init__(self.modeladmin, self.request, self.queryset)
 
-        self.fields["work"].label_from_instance = lambda obj: (
-            f"{obj.name} ({obj.category})"
+    def clean_work_selection(self):
+        value = self.cleaned_data.get("work_selection", "")
+
+        # "search" sentinel means the autocomplete radio was selected;
+        # read the actual pk from the work_search field.
+        if value == "search":
+            search_pk = self.data.get("work_search", "")
+            if search_pk:
+                value = f"work:{search_pk}"
+
+        if value.startswith("work:"):
+            try:
+                pk = int(value.removeprefix("work:"))
+                return ("work", models.Work.objects.get(pk=pk))
+            except (ValueError, models.Work.DoesNotExist):
+                raise forms.ValidationError("Selected work not found.")
+        elif value.startswith("nomination:"):
+            try:
+                pk = int(value.removeprefix("nomination:"))
+                return ("nomination", nominate.Nomination.objects.get(pk=pk))
+            except (ValueError, nominate.Nomination.DoesNotExist):
+                raise forms.ValidationError("Selected nomination not found.")
+        raise forms.ValidationError("Please select a work or nomination.")
+
+    def action_form_view(self, request, extra_context=None):
+        return super().action_form_view(
+            request,
+            extra_context={
+                "matching_works": self.matching_works,
+                **(extra_context or {}),
+            },
         )
 
     def __post_init__(
@@ -87,81 +115,34 @@ class GroupNominationsForm(AdminActionForm):
                 "The nominations selected must come from exactly one election"
             )
 
-        first_nomination = queryset.first()
-
-        self.fields["work"].queryset = (
-            self.fields["work"]
-            .queryset.select_related("category")
-            .filter(category__in=categories)
-            .order_by("name")
-        )
-
-        if first_nomination:
-            work = models.Work.find_match_based_on_identical_nomination(
-                first_nomination.proposed_work_name(), first_nomination.category
+        similarity_totals: dict[int, float] = {}
+        similarity_counts: dict[int, int] = {}
+        works_by_pk: dict[int, models.Work] = {}
+        nomination_count = queryset.count()
+        for nomination in queryset:
+            works = models.Work.find_fuzzy_matches(
+                nomination.proposed_work_name(), nomination.category
             )
+            for work in works:
+                similarity_totals[work.pk] = (
+                    similarity_totals.get(work.pk, 0) + work.similarity
+                )
+                similarity_counts[work.pk] = similarity_counts.get(work.pk, 0) + 1
+                works_by_pk[work.pk] = work
 
-            if work:
-                self.fields["work"].initial = work
-            else:
-                self.fields["work"].initial = self._find_closest_work(queryset)
-
-    def _find_closest_work(self, queryset: QuerySet) -> models.Work | None:
-        """Find the Work whose name is alphabetically closest to the most common
-        proposed_work_name() among the selected nominations.
-
-        If there's a clear mode (most frequent name), use it as the target.
-        Otherwise, use the first nomination's proposed_work_name().
-        """
-        proposed_names = [n.proposed_work_name() for n in queryset]
-        proposed_names = [
-            name.strip() for name in proposed_names if name and name.strip()
-        ]
-
-        if not proposed_names:
-            return None
-
-        counts = Counter(proposed_names)
-        most_common = counts.most_common(2)
-
-        if len(most_common) > 1 and most_common[0][1] == most_common[1][1]:
-            # No clear mode; all tied. Use the first nomination's name.
-            target = proposed_names[0]
-        else:
-            target = most_common[0][0]
-
-        works = list(self.fields["work"].queryset)
-        if not works:
-            return None
-
-        work_names_lower = [w.name.lower() for w in works]
-        target_lower = target.lower()
-
-        idx = bisect.bisect_left(work_names_lower, target_lower)
-
-        # Pick the nearest neighbor: compare the entry at idx and idx-1
-        if idx == 0:
-            return works[0]
-        if idx >= len(works):
-            return works[-1]
-
-        # Compare distance to neighbors; since these are strings,
-        # "closest" means the one that sorts nearest
-        before = work_names_lower[idx - 1]
-        after = work_names_lower[idx]
-
-        if target_lower == before or target_lower == after:
-            # Exact match
-            return works[idx] if target_lower == after else works[idx - 1]
-
-        # For string proximity, pick whichever would appear adjacent
-        # in a sorted list. Since bisect_left gives us the insertion point,
-        # both neighbors are valid; prefer the one after (higher) for consistency.
-        return works[idx]
+        avg_similarity: dict[int, float] = {
+            pk: similarity_totals[pk] / nomination_count for pk in works_by_pk
+        }
+        self.matching_works = sorted(
+            works_by_pk.values(), key=lambda w: avg_similarity[w.pk], reverse=True
+        )
+        for work in self.matching_works:
+            work.similarity_pct = round(avg_similarity[work.pk] * 100)
 
     class Meta:
-        list_objects = True
-        help_text = "Group these nominations?"
+        help_text = "Select work to group under"
+        fieldsets = [(None, {"fields": ["work_selection", "work_search"]})]
+        autocomplete_fields = ["work_search"]
 
 
 @action_with_form(
@@ -170,10 +151,19 @@ class GroupNominationsForm(AdminActionForm):
 def group_works(
     modeladmin: admin.ModelAdmin, request: HttpRequest, queryset: QuerySet, data: dict
 ) -> None:
-    work = data.get("work")
+    selection_type, selection_obj = data.get("work_selection")
 
     with transaction.atomic():
-        work = models.group_nominations(queryset, work)
+        if selection_type == "work":
+            work = models.group_nominations(queryset, selection_obj)
+        elif selection_type == "nomination":
+            work = models.Work.objects.create(
+                name=selection_obj.proposed_work_name(),
+                category=selection_obj.category,
+            )
+            work = models.group_nominations(queryset, work)
+        else:
+            raise ValueError("Invalid selection type")
         work.save()
 
 

--- a/src/nomnom/canonicalize/models.py
+++ b/src/nomnom/canonicalize/models.py
@@ -4,6 +4,8 @@ from django.db.models import F, Q, Value
 from django.db.models.functions import Concat, Lower
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+from django.contrib.postgres.search import TrigramWordSimilarity
+from django.db.models.functions import Greatest
 
 from nomnom.nominate import models as nominate
 
@@ -37,15 +39,13 @@ class Work(models.Model):
     def __str__(self) -> str:
         return self.name
 
-    @classmethod
-    def find_match_based_on_identical_nomination(
-        cls, name: str, category: "nominate.Category"
-    ) -> "Work | None":
+    @staticmethod
+    def _combined_nomination_name(category: "nominate.Category"):
         field_count = category.fields
         if field_count == 1:
-            combined_name = Lower(F("nominations__field_1"))
+            return Lower(F("nominations__field_1"))
         elif field_count == 2:
-            combined_name = Lower(
+            return Lower(
                 Concat(
                     "nominations__field_1",
                     Value(" "),
@@ -53,7 +53,7 @@ class Work(models.Model):
                 )
             )
         elif field_count == 3:
-            combined_name = Lower(
+            return Lower(
                 Concat(
                     "nominations__field_1",
                     Value(" "),
@@ -64,12 +64,36 @@ class Work(models.Model):
             )
         else:
             raise ValueError("Unsupported field count")
+
+    @classmethod
+    def find_match_based_on_identical_nomination(
+        cls, name: str, category: "nominate.Category"
+    ) -> "Work | None":
+        combined_name = cls._combined_nomination_name(category)
         query = (
             cls.objects.filter(category=category)
             .annotate(combined_name=combined_name, work_name=Lower(F("name")))
             .filter(Q(combined_name=name.lower()) | Q(work_name=name.lower()))
         )
         return query.first()
+
+    @classmethod
+    def find_fuzzy_matches(
+        cls, name: str, category: "nominate.Category", limit: int = 3
+    ) -> list["Work"]:
+        combined_name = cls._combined_nomination_name(category)
+
+        name_similarity = TrigramWordSimilarity(name, "name")
+        nomination_similarity = TrigramWordSimilarity(name, combined_name)
+        best_similarity = Greatest(name_similarity, nomination_similarity)
+
+        return list(
+            cls.objects.filter(category=category)
+            .annotate(similarity=best_similarity)
+            .filter(similarity__gt=0.3)
+            .order_by("-similarity")
+            .distinct()[:limit]
+        )
 
     def combine_works(self, other_works) -> None:
         """Combine this work with other works.

--- a/src/nomnom/canonicalize/templates/canonicalize/group_nominations_action_form.html
+++ b/src/nomnom/canonicalize/templates/canonicalize/group_nominations_action_form.html
@@ -1,0 +1,88 @@
+{% extends "django_admin_action_forms/action_form.html" %}
+{% load i18n %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <style>
+    input[type="radio"][name="work_selection"] { margin-right: 0.4em; }
+    .group-nominations-list { list-style-type: none; padding-left: 0; }
+    .group-nominations-list li { list-style-type: none; margin-bottom: 0.3em; }
+    .section-divider { color: #999; margin: 1em 0 0.5em; }
+    .autocomplete-row { display: flex; align-items: center; gap: 0.4em; margin-bottom: 0.3em; }
+  </style>
+{% endblock %}
+
+{% block action_form %}
+  <form method="post">
+    <h2>{% translate "Create from a Raw Nomination" %}</h2>
+    <ul class="group-nominations-list">
+      {% for object in queryset %}
+        <li>
+          <label>
+            <input type="radio" name="work_selection" value="nomination:{{ object.pk }}">
+            {{ object }}
+          </label>
+        </li>
+      {% endfor %}
+    </ul>
+
+    <p class="section-divider">&mdash; or &mdash;</p>
+
+    <h2>{% translate "Suggested Canonical Works" %}</h2>
+    {% if matching_works %}
+      <ul class="group-nominations-list">
+        {% for work in matching_works %}
+          <li>
+            <label>
+              <input type="radio" name="work_selection" value="work:{{ work.pk }}">
+              {{ work }} ({{ work.category }})
+            </label>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>{% translate "No matching canonicalized works found." %}</p>
+    {% endif %}
+
+    <p class="section-divider">&mdash; or &mdash;</p>
+
+    <h2>{% translate "Search Canonical Works" %}</h2>
+    <div class="autocomplete-row">
+      <input type="radio" name="work_selection" id="autocomplete-radio"
+        value="search">
+      {{ form.work_search }}
+    </div>
+
+    {% csrf_token %}
+    {{ form.work_selection.errors }}
+    <input type="hidden" name="action" value="{{ action }}" />
+    <input type="hidden" name="select_across" value="{{ select_across }}" />
+    {% for item in selected_action %}
+      <input type="hidden" name="_selected_action" value="{{ item }}" />
+    {% endfor %}
+    <input type="submit" value="{{ confirm_button_text }}">
+    <a href="#" class="button cancel-link">{{ cancel_button_text }}</a>
+  </form>
+
+  <script>
+    (function ($) {
+      const radio = $('#autocomplete-radio');
+      const $select = $('#id_work_search');
+
+      // Check the radio when an option is selected
+      $select.on('select2:select', function () {
+        radio.prop('checked', true);
+      });
+
+      // Uncheck the radio when the selection is cleared
+      $select.on('select2:clear select2:unselect', function () {
+        radio.prop('checked', false);
+      });
+
+      // Clear autocomplete when another radio is chosen
+      $('input[name="work_selection"]:not(#autocomplete-radio)').on('change', function () {
+        $select.val(null).trigger('change');
+      });
+    }(django.jQuery));
+  </script>
+{% endblock %}

--- a/src/nomnom/canonicalize/tests/test_admin.py
+++ b/src/nomnom/canonicalize/tests/test_admin.py
@@ -1,9 +1,11 @@
 import pytest
+from django.contrib import admin
 from django.core.exceptions import ValidationError
 from django.test.client import RequestFactory
 
-from nomnom.canonicalize.admin import GroupNominationsForm
+from nomnom.canonicalize.admin import GroupNominationsForm, NominationGroupingView
 from nomnom.canonicalize.factories import WorkFactory
+from nomnom.canonicalize.models import CanonicalizedNomination
 from nomnom.nominate.factories import CategoryFactory, NominationFactory
 from nomnom.nominate.models import Nomination
 
@@ -25,44 +27,52 @@ def make_category():
     return CategoryFactory
 
 
-def test_form_filters_queryset_to_category(
-    work_factory, nomination_factory, category_factory
+@pytest.fixture(name="modeladmin")
+def make_modeladmin():
+    return NominationGroupingView(CanonicalizedNomination, admin.site)
+
+
+def test_matching_works_only_includes_works_from_same_category(
+    work_factory, nomination_factory, category_factory, modeladmin
 ):
     category = category_factory()
-    work_factory(category=category)
+    other_category = category_factory()
+    work_factory(name="Example", category=category)
+    work_factory(name="Example", category=other_category)
     nomination_factory(category=category, field_1="Example")
     request = RequestFactory().get("/admin/canonicalize/canonicalizednomination/")
 
     form = GroupNominationsForm(
-        modeladmin=None,
+        modeladmin=modeladmin,
         action="group_works",
         request=request,
         queryset=Nomination.objects.all(),
     )
 
-    assert all(w.category == category for w in form.fields["work"].queryset)
+    assert all(w.category == category for w in form.matching_works)
 
 
-def test_form_sets_initial_if_matching_work_exists(
-    work_factory, nomination_factory, category_factory
+def test_matching_works_finds_similar_work(
+    work_factory, nomination_factory, category_factory, modeladmin
 ):
     category = category_factory()
     nomination = nomination_factory(category=category, field_1="Example")
     matching_work = work_factory(
         category=category, name=nomination.proposed_work_name()
     )
-    matching_work.nominations.add(nomination)
     request = RequestFactory().get("/admin/canonicalize/canonicalizednomination/")
     queryset = Nomination.objects.all()
 
     form = GroupNominationsForm(
-        modeladmin=None, action="group_works", request=request, queryset=queryset
+        modeladmin=modeladmin, action="group_works", request=request, queryset=queryset
     )
 
-    assert form.fields["work"].initial == matching_work
+    assert matching_work in form.matching_works
 
 
-def test_form_raises_error_for_multiple_elections(nomination_factory, category_factory):
+def test_form_raises_error_for_multiple_elections(
+    nomination_factory, category_factory, modeladmin
+):
     cat1 = category_factory()
     cat2 = category_factory()
     nomination_factory(category=cat1, field_1="One")
@@ -72,136 +82,105 @@ def test_form_raises_error_for_multiple_elections(nomination_factory, category_f
 
     with pytest.raises(ValidationError, match="must come from exactly one election"):
         GroupNominationsForm(
-            modeladmin=None, action="group_works", request=request, queryset=queryset
+            modeladmin=modeladmin,
+            action="group_works",
+            request=request,
+            queryset=queryset,
         )
 
 
-def test_work_queryset_is_ordered_and_filtered(
-    work_factory, nomination_factory, category_factory
+def test_matching_works_ordered_by_similarity(
+    work_factory, nomination_factory, category_factory, modeladmin
 ):
     category = category_factory()
-    nomination_factory(category=category, field_1="ABC")
-    work_factory(name="Zebra", category=category)
-    work_factory(name="Apple", category=category)
+    nomination_factory(category=category, field_1="The Hobbit")
+    fuzzy = work_factory(name="The Hobbits Journey", category=category)
+    exact = work_factory(name="The Hobbit", category=category)
     request = RequestFactory().get("/admin/canonicalize/canonicalizednomination/")
     queryset = Nomination.objects.all()
 
     form = GroupNominationsForm(
-        modeladmin=None, action="group_works", request=request, queryset=queryset
+        modeladmin=modeladmin, action="group_works", request=request, queryset=queryset
     )
-    qs = list(form.fields["work"].queryset)
 
-    assert qs == sorted(qs, key=lambda w: w.name)
-    assert all(w.category == category for w in qs)
+    assert form.matching_works[0] == exact
+    assert fuzzy in form.matching_works
 
 
-def test_work_field_label_from_instance(
-    work_factory, nomination_factory, category_factory
+def test_matching_works_have_similarity_pct(
+    work_factory, nomination_factory, category_factory, modeladmin
 ):
-    category = category_factory(name="Best Graphic Story")
+    category = category_factory()
     nomination_factory(category=category, field_1="Example")
-    work = work_factory(name="Saga", category=category)
+    work_factory(name="Example", category=category)
     request = RequestFactory().get("/admin/canonicalize/canonicalizednomination/")
     form = GroupNominationsForm(
-        modeladmin=None,
+        modeladmin=modeladmin,
         action="group_works",
         request=request,
         queryset=Nomination.objects.all(),
     )
-    label_func = form.fields["work"].label_from_instance
-    assert label_func(work) == f"{work.name} ({work.category})"
+
+    assert len(form.matching_works) > 0
+    assert all(hasattr(w, "similarity_pct") for w in form.matching_works)
 
 
-def test_form_raises_error_when_no_nominations_selected():
+def test_form_raises_error_when_no_nominations_selected(modeladmin):
     empty_queryset = Nomination.objects.none()
     request = RequestFactory().get("/admin/canonicalize/canonicalizednomination/")
     with pytest.raises(ValidationError, match="at least one nomination"):
         GroupNominationsForm(
-            modeladmin=None,
+            modeladmin=modeladmin,
             action="group_works",
             request=request,
             queryset=empty_queryset,
         )
 
 
-def test_closest_work_when_mode_matches_exactly(
-    work_factory, nomination_factory, category_factory
+def test_matching_works_ranks_exact_name_match_highest(
+    work_factory, nomination_factory, category_factory, modeladmin
 ):
-    """When the most common proposed_work_name has an exact work name match,
-    the form selects that work as initial (via the closest-alphabetical fallback)."""
+    """When multiple nominations share a name that exactly matches a work,
+    that work should rank highest in matching_works."""
     category = category_factory()
-    # Three nominations with the same name, no work has them linked
     nomination_factory(category=category, field_1="Dune")
     nomination_factory(category=category, field_1="Dune")
     nomination_factory(category=category, field_1="Neuromancer")
-    # Works exist but none has nominations linked (so exact-match via
-    # find_match_based_on_identical_nomination won't fire)
     work_factory(name="Babel", category=category)
     target_work = work_factory(name="Dune", category=category)
     work_factory(name="Foundation", category=category)
     request = RequestFactory().get("/admin/canonicalize/canonicalizednomination/")
 
     form = GroupNominationsForm(
-        modeladmin=None,
+        modeladmin=modeladmin,
         action="group_works",
         request=request,
         queryset=Nomination.objects.all(),
     )
 
-    assert form.fields["work"].initial == target_work
+    assert target_work in form.matching_works
+    assert form.matching_works[0] == target_work
 
 
-def test_closest_work_when_mode_is_close_alphabetically(
-    work_factory, nomination_factory, category_factory
+def test_matching_works_uses_average_similarity_across_nominations(
+    work_factory, nomination_factory, category_factory, modeladmin
 ):
-    """When the most common proposed_work_name doesn't exactly match any work,
-    the form selects the alphabetically nearest work."""
+    """A work that matches most nominations should rank higher than one
+    matching only a single nomination."""
     category = category_factory()
-    # Most common name is "Dungeon" — no work with that exact name
-    nomination_factory(category=category, field_1="Dungeon")
-    nomination_factory(category=category, field_1="Dungeon")
-    nomination_factory(category=category, field_1="Zebra")
-    # Works: "Babel", "Dune", "Foundation" — "Dune" is the closest alphabetically
-    # to "Dungeon" (it sorts before "Dungeon"; "Foundation" sorts after)
-    work_factory(name="Babel", category=category)
-    work_factory(name="Dune", category=category)
-    expected_work = work_factory(name="Foundation", category=category)
-    request = RequestFactory().get("/admin/canonicalize/canonicalizednomination/")
-
-    form = GroupNominationsForm(
-        modeladmin=None,
-        action="group_works",
-        request=request,
-        queryset=Nomination.objects.all(),
-    )
-
-    # "Dungeon" sorts between "Dune" and "Foundation"; bisect picks the one after
-    assert form.fields["work"].initial == expected_work
-
-
-def test_closest_work_when_no_mode_uses_first_nomination(
-    work_factory, nomination_factory, category_factory
-):
-    """When all proposed_work_names are different (no mode), the form uses the
-    first nomination's name to find the closest work."""
-    category = category_factory()
-    # All different names — no mode. First nomination is "Babel" (ordered by field_1
-    # via the queryset's default ordering)
-    nomination_factory(category=category, field_1="Babel")
     nomination_factory(category=category, field_1="Dune")
-    nomination_factory(category=category, field_1="Foundation")
-    # Works that don't match any nomination exactly
-    work_factory(name="Axiom", category=category)
-    expected_work = work_factory(name="Babel-17", category=category)
-    work_factory(name="Cryptonomicon", category=category)
+    nomination_factory(category=category, field_1="Dune")
+    nomination_factory(category=category, field_1="Dune")
+    # "Dune" matches all 3, "Neuromancer" matches none
+    dune_work = work_factory(name="Dune", category=category)
+    work_factory(name="Neuromancer", category=category)
     request = RequestFactory().get("/admin/canonicalize/canonicalizednomination/")
 
     form = GroupNominationsForm(
-        modeladmin=None,
+        modeladmin=modeladmin,
         action="group_works",
         request=request,
         queryset=Nomination.objects.all(),
     )
 
-    # "Babel" is the first nomination's name; "Babel-17" is the closest work
-    assert form.fields["work"].initial == expected_work
+    assert form.matching_works[0] == dune_work

--- a/src/nomnom/canonicalize/tests/test_models.py
+++ b/src/nomnom/canonicalize/tests/test_models.py
@@ -93,6 +93,17 @@ def test_nomination_associates_with_work_with_matching_name(category):
     assert new_nom.work == w1
 
 
+def test_nomination_does_not_auto_link_to_similar_but_non_identical_work(category):
+    """A nomination that is similar but not identical to an existing work
+    should not be automatically linked by the post_save signal."""
+    work = WorkFactory.create(name="The Hobbit", category=category)
+    nomination = NominationFactory.create(category=category, field_1="The Hobbits")
+    nomination.refresh_from_db()
+
+    assert nomination.work is None
+    assert nomination not in work.nominations.all()
+
+
 def test_combine_works_moves_nominations(category):
     """Ensure nominations from other works are properly transferred."""
     w1 = WorkFactory.create(category=category)
@@ -309,3 +320,65 @@ def test_finds_matching_work_by_nomination_ignoring_case(db, fields):
 
     # Assert: Should match even if field case varies
     assert matched_work == work
+
+
+def test_find_matches_returns_multiple_results(db):
+    """Ensure find_fuzzy_matches returns multiple similar works."""
+    category = CategoryFactory.create()
+    work1 = WorkFactory.create(name="The Hobbit", category=category)
+    work2 = WorkFactory.create(
+        name="The Hobbit: An Unexpected Journey", category=category
+    )
+    WorkFactory.create(name="Completely Different Title", category=category)
+
+    results = Work.find_fuzzy_matches("The Hobbit", category)
+
+    assert work1 in results
+    assert work2 in results
+
+
+def test_find_matches_ordered_by_similarity(db):
+    """Ensure results are ordered by similarity, best match first."""
+    category = CategoryFactory.create()
+    fuzzy = WorkFactory.create(name="The Hobbits Journey", category=category)
+    exact = WorkFactory.create(name="The Hobbit", category=category)
+
+    results = Work.find_fuzzy_matches("The Hobbit", category)
+
+    assert results[0] == exact
+    assert fuzzy in results
+
+
+def test_find_matches_respects_limit(db):
+    """Ensure find_fuzzy_matches respects the limit parameter."""
+    category = CategoryFactory.create()
+    for i in range(5):
+        WorkFactory.create(name=f"The Hobbit Volume {i}", category=category)
+
+    results = Work.find_fuzzy_matches("The Hobbit", category, limit=2)
+
+    assert len(results) <= 2
+
+
+def test_find_matches_excludes_low_similarity(db):
+    """Ensure works with low similarity are not returned."""
+    category = CategoryFactory.create()
+    WorkFactory.create(name="Completely Unrelated Title", category=category)
+
+    results = Work.find_fuzzy_matches("The Hobbit", category)
+
+    assert len(results) == 0
+
+
+def test_find_matches_by_linked_nomination_fields(db):
+    """Ensure matching works via nomination fields linked to a work."""
+    category = CategoryFactory.create(fields=2)
+    work = WorkFactory.create(name="Different Name Entirely", category=category)
+    nomination = NominationFactory.create(
+        category=category, field_1="The Hobbit", field_2="Tolkien"
+    )
+    work.nominations.add(nomination)
+
+    results = Work.find_fuzzy_matches("The Hobbit Tolkien", category)
+
+    assert work in results


### PR DESCRIPTION
Customize the group nominations action form to make it possible to: 1) Select which of the new works to use as the new canonicalized for 2) Search for existing canonicalized forms

Also show more than 1 potential match for existing canonicalized forms, allowing for fuzzier matching.

<img width="1264" height="1296" alt="image" src="https://github.com/user-attachments/assets/70f5a496-7570-48e8-9615-bb67145f64e2" />