### PR TITLE
introduce structlog

### DIFF
--- a/convention-template/config/settings.py.jinja
+++ b/convention-template/config/settings.py.jinja
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import bleach.sanitizer
 import djp
+import structlog
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -35,9 +36,7 @@ TEMPLATE_DEBUG = cfg.debug
 
 class InvalidStringShowWarning(str):
     def __mod__(self, other):
-        import logging
-
-        logger = logging.getLogger(__name__)
+        logger = structlog.get_logger(__name__)
         logger.warning(
             f"In template, undefined variable or unknown value for: '{other}'"
         )
@@ -93,6 +92,8 @@ INSTALLED_APPS = [
     "watchman",
     # Markdown field support
     "markdownfield",
+    # Structured logging
+    "django_structlog",
     # the convention theme; this MUST come before the nominate app, so that its templates can
     # override the nominate ones.
     "{{ app }}",
@@ -137,7 +138,10 @@ MIDDLEWARE = [
     "django_htmx.middleware.HtmxMiddleware",
     "nomnom.middleware.HtmxMessageMiddleware",
     "waffle.middleware.WaffleMiddleware",
+    "django_structlog.middlewares.RequestMiddleware",
 ]
+
+DJANGO_STRUCTLOG_CELERY_ENABLED = True
 
 ROOT_URLCONF = "config.urls"
 
@@ -337,6 +341,24 @@ EMAIL_HOST_USER = cfg.email.host_user
 EMAIL_HOST_PASSWORD = cfg.email.host_password
 EMAIL_USE_TLS = cfg.email.use_tls
 
+# Structlog configuration - must come before LOGGING
+structlog.configure(
+    processors=[
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.filter_by_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.UnicodeDecoder(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    ],
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    cache_logger_on_first_use=True,
+)
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -346,32 +368,69 @@ LOGGING = {
         },
     },
     "formatters": {
-        "verbose": {
-            "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
-            "style": "{",
+        "plain_console": {
+            "()": "structlog.stdlib.ProcessorFormatter",
+            "processors": [
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                structlog.dev.ConsoleRenderer(colors=True),
+            ],
+            "foreign_pre_chain": [
+                structlog.contextvars.merge_contextvars,
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.add_logger_name,
+            ],
         },
-        "simple": {
-            "format": "{levelname} {message}",
-            "style": "{",
+        "json": {
+            "()": "structlog.stdlib.ProcessorFormatter",
+            "processors": [
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                structlog.processors.JSONRenderer(),
+            ],
+            "foreign_pre_chain": [
+                structlog.contextvars.merge_contextvars,
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.add_logger_name,
+            ],
         },
     },
     "handlers": {
         "console": {
             "level": "INFO",
             "class": "logging.StreamHandler",
-            "formatter": "simple",
+            "formatter": "plain_console" if DEBUG else "json",
         },
         "debug_console": {
             "level": "DEBUG",
             "filters": ["require_debug_true"],
             "class": "logging.StreamHandler",
-            "formatter": "simple",
+            "formatter": "plain_console",
         },
     },
     "loggers": {
         "django.db.backends": {
             "level": "DEBUG",
             "handlers": ["debug_console"],
+        },
+        "django_structlog": {
+            "handlers": ["console"],
+            "level": "INFO",
+        },
+        "django.server": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "django.request": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        # Root logger - catches all logs not matched by more specific loggers
+        "": {
+            "handlers": ["console"],
+            "level": "DEBUG" if DEBUG else "INFO",
         },
     },
 }

--- a/docs/docs/dev/index.md
+++ b/docs/docs/dev/index.md
@@ -83,6 +83,21 @@ domain name.
 When copier finishes, it outputs a series of further steps to follow to
 set up and run NomNom.
 
+## Development Server Notes
+
+### Reducing Log Verbosity in Development
+
+If you find the duplicate request logs too noisy during development, you can:
+
+1. **Suppress django-structlog request logs** by setting the environment variable:
+   ```bash
+   DJANGO_LOG_LEVEL=WARNING python manage.py runserver
+   ```
+
+2. **Filter out static file requests** by adjusting the logger level for specific paths in your application code.
+
+The built-in Django request handler logs cannot be suppressed without creating a custom runserver command, but they're harmless and won't appear in production.
+
 ## Contributing
 
 All contributions should be made through pull requests (yes, I'm a bit of a hypocrite in that regard, as I do frequently develop on `main`. Nevertheless.)

--- a/justfile
+++ b/justfile
@@ -70,6 +70,7 @@ environment-check:
     ./scripts/setup-env.sh
 
 services:
+    mkdir -p .local/logs
     docker compose up --wait
 
 docker-ports:

--- a/nomnom_dev/settings.py
+++ b/nomnom_dev/settings.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import bleach.sanitizer
 import djp
+import structlog
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -60,9 +61,7 @@ TEMPLATE_DEBUG = cfg.debug
 
 class InvalidStringShowWarning(str):
     def __mod__(self, other):
-        import logging
-
-        logger = logging.getLogger(__name__)
+        logger = structlog.get_logger(__name__)
         logger.warning(
             f"In template, undefined variable or unknown value for: '{other}'"
         )
@@ -122,6 +121,8 @@ INSTALLED_APPS = [
     "markdownfield",
     # Feature flags
     "waffle",
+    # Structured logging
+    "django_structlog",
     # the convention theme; this MUST come before the nominate app, so that its templates can
     # override the nominate ones.
     "nomnom_dev",
@@ -164,7 +165,10 @@ MIDDLEWARE = [
     "django_htmx.middleware.HtmxMiddleware",
     "nomnom.middleware.HtmxMessageMiddleware",
     "waffle.middleware.WaffleMiddleware",
+    "django_structlog.middlewares.RequestMiddleware",
 ]
+
+DJANGO_STRUCTLOG_CELERY_ENABLED = True
 
 ROOT_URLCONF = "nomnom_dev.urls"
 
@@ -366,6 +370,24 @@ EMAIL_HOST_USER = cfg.email.host_user
 EMAIL_HOST_PASSWORD = cfg.email.host_password
 EMAIL_USE_TLS = cfg.email.use_tls
 
+# Structlog configuration - must come before LOGGING
+structlog.configure(
+    processors=[
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.filter_by_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.UnicodeDecoder(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    ],
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    cache_logger_on_first_use=True,
+)
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -375,32 +397,77 @@ LOGGING = {
         },
     },
     "formatters": {
-        "verbose": {
-            "format": "{levelname} {asctime} {module} {process:d} {thread:d} {message}",
-            "style": "{",
+        "plain_console": {
+            "()": "structlog.stdlib.ProcessorFormatter",
+            "processors": [
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                structlog.dev.ConsoleRenderer(colors=True),
+            ],
+            "foreign_pre_chain": [
+                structlog.contextvars.merge_contextvars,
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.add_logger_name,
+            ],
         },
-        "simple": {
-            "format": "{levelname} {message}",
-            "style": "{",
+        "json": {
+            "()": "structlog.stdlib.ProcessorFormatter",
+            "processors": [
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                structlog.processors.JSONRenderer(),
+            ],
+            "foreign_pre_chain": [
+                structlog.contextvars.merge_contextvars,
+                structlog.processors.TimeStamper(fmt="iso"),
+                structlog.stdlib.add_log_level,
+                structlog.stdlib.add_logger_name,
+            ],
         },
     },
     "handlers": {
         "console": {
             "level": "INFO",
             "class": "logging.StreamHandler",
-            "formatter": "simple",
+            "formatter": "plain_console" if DEBUG else "json",
         },
         "debug_console": {
             "level": "DEBUG",
             "filters": ["require_debug_true"],
             "class": "logging.StreamHandler",
-            "formatter": "simple",
+            "formatter": "plain_console",
+        },
+        "json_file": {
+            "level": "DEBUG",
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": BASE_DIR / ".local/logs" / "json.log",
+            "maxBytes": 10485760,  # 10MB
+            "backupCount": 5,
+            "formatter": "json",
         },
     },
     "loggers": {
         "django.db.backends": {
             "level": os.environ.get("DJANGO_DB_LOG_LEVEL", "INFO"),
             "handlers": ["debug_console"],
+        },
+        "django_structlog": {
+            "handlers": ["console", "json_file"],
+            "level": "INFO",
+        },
+        "django.server": {
+            "handlers": ["console", "json_file"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "django.request": {
+            "handlers": ["console", "json_file"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        # Root logger - catches all logs not matched by more specific loggers
+        "": {
+            "handlers": ["console", "json_file"],
+            "level": "DEBUG" if DEBUG else "INFO",
         },
     },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ dependencies = [
     "inflect>=7.5.0",
     "rich>=13.9.4",
     "faker>=37.6.0",
+    "django-admin-sortable2>=2.3.1",
+    "structlog>=24.0",
+    "django-structlog[celery]>=9.0",
 ]
 requires-python = ">=3.13.0,<3.14"
 readme = "README.md"

--- a/src/nomnom/celery.py
+++ b/src/nomnom/celery.py
@@ -1,6 +1,8 @@
 import os
 
 from celery import Celery
+from celery.signals import setup_logging
+from django_structlog.celery.steps import DjangoStructLogInitStep
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
@@ -8,9 +10,23 @@ app = Celery("nomnom")
 
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
+app.steps["worker"].add(DjangoStructLogInitStep)  # type: ignore[assignment]
+
 app.autodiscover_tasks()
 
 
 @app.task(bind=True, ignore_result=True)
 def debug_task(self):
     print(f"Request: {self.request!r}")
+
+
+@setup_logging.connect
+def setup_celery_logging(loglevel, logfile, format, colorize, **kwargs):
+    import logging
+
+    from django.conf import settings
+
+    # importing settings and using LOGGING should automatically
+    # configure structlog.
+    settings_log_config = settings.LOGGING
+    logging.config.dictConfig(settings_log_config)

--- a/src/nomnom/hugopacket/views.py
+++ b/src/nomnom/hugopacket/views.py
@@ -1,6 +1,7 @@
 from functools import wraps
 from urllib.parse import urlparse
 
+import structlog
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required, permission_required
@@ -20,6 +21,8 @@ from nomnom.hugopacket.models import (
     PacketItemAccess,
 )
 from nomnom.nominate.models import Election
+
+logger = structlog.get_logger(__name__)
 
 
 def request_passes_test(
@@ -216,6 +219,11 @@ def download_packet(
                 )
 
                 if not unassigned_code:
+                    logger.error(
+                        "no distribution codes available",
+                        packet_file_id=packet_file.id,
+                        member_id=member.id,
+                    )
                     return render(
                         request,
                         "hugopacket/no_codes_available.html",
@@ -228,6 +236,13 @@ def download_packet(
                 unassigned_code.assigned_at = timezone.now()
                 unassigned_code.save(update_fields=["assigned_at"])
                 access.save(update_fields=["distribution_code"])
+
+                logger.info(
+                    "assigned distribution code",
+                    packet_file_id=packet_file.id,
+                    member_id=member.id,
+                    code_id=unassigned_code.id,
+                )
 
         # Record the access
         access.increment_access()

--- a/uv.lock
+++ b/uv.lock
@@ -514,6 +514,18 @@ wheels = [
 ]
 
 [[package]]
+name = "django-admin-sortable2"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/09/cc2d19412e47aaf627f54f9b5b544de73553bd71e25d417dd62e91b36edd/django_admin_sortable2-2.3.1.tar.gz", hash = "sha256:e397d08606f9e0da73e52661b841021ecab21be6f74783408e625ccddfe975af", size = 67497, upload-time = "2026-01-22T14:20:29.049Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/77/4396e853c3ee3b1264a2bb23f9b1934194ab750c6ecd30aa194b53dec7b9/django_admin_sortable2-2.3.1-py3-none-any.whl", hash = "sha256:5784f441f3532013438c3c3226fbccc39b9c733f867b26a5f477d6b05f734b93", size = 107015, upload-time = "2026-01-22T14:20:27.604Z" },
+]
+
+[[package]]
 name = "django-bootstrap-static"
 version = "5.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -764,6 +776,26 @@ dependencies = [
     { name = "toposort" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/19/0423c1a8adb10c9e246f3a0e661165a7851bb7f4253eb338624081343e76/django-seed-0.3.1.tar.gz", hash = "sha256:93e65d2c10449c464b83e9031be02763ec10e786aa064d649c4dd5ad06fa0eea", size = 18336, upload-time = "2021-10-08T16:30:29.522Z" }
+
+[[package]]
+name = "django-structlog"
+version = "10.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+    { name = "django-ipware" },
+    { name = "structlog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/a9/102f316fb60dbec46642168979c4f57c9d8140fe43624ddca1ca6106274a/django_structlog-10.0.0.tar.gz", hash = "sha256:4e3fa4a930697fb9b649470e389419bb73b916a1ecf4f4bf2f8727f5cbfdb002", size = 23054, upload-time = "2025-10-22T21:20:21.14Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/83/d7245a2a2bb46ae65ecff00686181d632553b131ea0c5cbfcbdb8f89c190/django_structlog-10.0.0-py3-none-any.whl", hash = "sha256:4f9db3cb7b308df6aa4afe1353d9c19d5bac757022ddbbb5c24f3d0d6a91a240", size = 18159, upload-time = "2025-10-22T21:20:19.804Z" },
+]
+
+[package.optional-dependencies]
+celery = [
+    { name = "celery" },
+]
 
 [[package]]
 name = "django-stubs"
@@ -1411,6 +1443,7 @@ dependencies = [
     { name = "django" },
     { name = "django-admin-action-forms" },
     { name = "django-admin-autocomplete-filter" },
+    { name = "django-admin-sortable2" },
     { name = "django-bootstrap-static" },
     { name = "django-bootstrap5" },
     { name = "django-browser-reload" },
@@ -1430,6 +1463,7 @@ dependencies = [
     { name = "django-oauth-toolkit" },
     { name = "django-render-block" },
     { name = "django-seed" },
+    { name = "django-structlog", extra = ["celery"] },
     { name = "django-svcs" },
     { name = "django-waffle" },
     { name = "django-watchman" },
@@ -1445,6 +1479,7 @@ dependencies = [
     { name = "rich" },
     { name = "sentry-sdk", extra = ["celery", "django"] },
     { name = "social-auth-core" },
+    { name = "structlog" },
     { name = "svcs" },
     { name = "whitenoise" },
 ]
@@ -1489,6 +1524,7 @@ requires-dist = [
     { name = "django", specifier = ">=5.2.11,<6.0" },
     { name = "django-admin-action-forms", specifier = "~=2.0" },
     { name = "django-admin-autocomplete-filter", specifier = "~=0.7" },
+    { name = "django-admin-sortable2", specifier = ">=2.3.1" },
     { name = "django-bootstrap-static", specifier = ">=5.3.3" },
     { name = "django-bootstrap5", specifier = ">=23.3,<27.0" },
     { name = "django-browser-reload", specifier = "~=1.12" },
@@ -1508,6 +1544,7 @@ requires-dist = [
     { name = "django-oauth-toolkit", specifier = "~=3.0" },
     { name = "django-render-block", specifier = "~=0.9" },
     { name = "django-seed", specifier = "~=0.3" },
+    { name = "django-structlog", extras = ["celery"], specifier = ">=9.0" },
     { name = "django-svcs", specifier = "~=0.3" },
     { name = "django-waffle", specifier = ">=5.0.0" },
     { name = "django-watchman", specifier = "~=1.3" },
@@ -1523,6 +1560,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.9.4" },
     { name = "sentry-sdk", extras = ["celery", "django"], specifier = "~=2.44.0" },
     { name = "social-auth-core", specifier = "~=4.5" },
+    { name = "structlog", specifier = ">=24.0" },
     { name = "svcs", specifier = ">=24.1,<26.0" },
     { name = "whitenoise", specifier = "~=6.6" },
 ]
@@ -2233,6 +2271,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/67/701f86b28d63b2086de47c942eccf8ca2208b3be69715a1119a4e384415a/sqlparse-0.5.4.tar.gz", hash = "sha256:4396a7d3cf1cd679c1be976cf3dc6e0a51d0111e87787e7a8d780e7d5a998f9e", size = 120112, upload-time = "2025-11-28T07:10:18.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/70/001ee337f7aa888fb2e3f5fd7592a6afc5283adb1ed44ce8df5764070f22/sqlparse-0.5.4-py3-none-any.whl", hash = "sha256:99a9f0314977b76d776a0fcb8554de91b9bb8a18560631d6bc48721d07023dcb", size = 45933, upload-time = "2025-11-28T07:10:19.73Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- add structlog to the dependencies
- configure structlog in dev and production modes
- configure structlog in the template (future use)
- log as json in the dev server

Blocked by https://github.com/jrobichaud/django-structlog/pull/1024 so I can control logging levels in development more easily.