### PR TITLE
Wordsmith text on show/hide individual downloads buttons

### DIFF
--- a/convention-template/{{ app}}/templates/hugopacket/bits/section.html
+++ b/convention-template/{{ app}}/templates/hugopacket/bits/section.html
@@ -39,7 +39,7 @@
                                         data-bs-target="#finalists-category-{{ section_data.section.id }}"
                                         aria-expanded="false"
                                         aria-controls="finalists-category-{{ section_data.section.id }}">
-                                    Show all downloads
+                                    Show individual downloads
                                 </button>
                             </div>
                         </div>

--- a/src/nomnom/hugopacket/templates/hugopacket/bits/section.html
+++ b/src/nomnom/hugopacket/templates/hugopacket/bits/section.html
@@ -39,7 +39,7 @@
                                         data-bs-target="#finalists-category-{{ section_data.section.id }}"
                                         aria-expanded="false"
                                         aria-controls="finalists-category-{{ section_data.section.id }}">
-                                    Show all downloads
+                                    Show individual downloads
                                 </button>
                             </div>
                         </div>

--- a/src/nomnom/hugopacket/templates/hugopacket/index.html
+++ b/src/nomnom/hugopacket/templates/hugopacket/index.html
@@ -101,7 +101,7 @@ document.addEventListener('DOMContentLoaded', function() {
         collapseEl.addEventListener('shown.bs.collapse', function() {
             const btn = document.querySelector('[data-bs-target="#' + collapseEl.id + '"]');
             if (btn) {
-                btn.textContent = 'Show only main download';
+                btn.textContent = 'Hide individual downloads';
                 btn.classList.remove('btn-outline-primary');
                 btn.classList.add('btn-outline-danger');
             }
@@ -111,7 +111,7 @@ document.addEventListener('DOMContentLoaded', function() {
         collapseEl.addEventListener('hidden.bs.collapse', function() {
             const btn = document.querySelector('[data-bs-target="#' + collapseEl.id + '"]');
             if (btn) {
-                btn.textContent = 'Show all downloads';
+                btn.textContent = 'Show individual downloads';
                 btn.classList.remove('btn-outline-danger');
                 btn.classList.add('btn-outline-primary');
             }


### PR DESCRIPTION
A packet tester for LAcon requested we make it more clear what these buttons do.

* This is my best guess at the tradeoff of clarity vs conciseness; suggestions welcome!
* It looks to me like these aren't customized in the LAcon site, so i have to change them here (but if we like the new wording, it seems okay to me to change it here)
* Also: i believe this is the right set of places to change, but i don't have a test nomnom installation yet, so let me know if i got it wrong