### PR TITLE
Add a button to claim distribution code

### DIFF
--- a/nomnom_dev/templates/hugopacket/bits/packet_file.html
+++ b/nomnom_dev/templates/hugopacket/bits/packet_file.html
@@ -2,8 +2,7 @@
 <div class="row" style="margin-bottom: 10px;">
     <div class="col-md-6">
         <a href="{% url "hugopacket:download_packet" election.slug packet.id %}">
-            {{ packet }}
-            {% if packet.access_type == 'code' %}<span class="badge bg-info">Code</span>{% endif %}
+            {{ packet }}{% if packet.access_type == 'code' %}<span class="badge bg-info ms-1">Code</span>{% endif %}
         </a>
         {% if packet.access_count > 0 %}
             <small class="text-muted ms-2">(accessed {{ packet.access_count }}×)</small>
@@ -12,11 +11,6 @@
     {% if packet.size %}<div class="col-md-3">{{ packet.size|filesizeformat }}</div>{% endif %}
     {% if packet.last_modified %}
         <div class="col-md-3" title="{{ packet.last_modified|date:"c" }}">{{ packet.last_modified|naturaltime }}</div>
-    {% endif %}
-    {% if packet.access_type == 'code' %}
-        <div class="col-12">
-            <strong>The number of codes is limited.</strong> To get a code, click the link — but please only take a code if you don't already have access to the item and intend to use it.
-        </div>
     {% endif %}
     {% if packet.description %}<div class="col-12">{{ packet.description|markdownify }}</div>{% endif %}
 </div>

--- a/src/nomnom/hugopacket/templates/hugopacket/display_code.html
+++ b/src/nomnom/hugopacket/templates/hugopacket/display_code.html
@@ -2,14 +2,14 @@
 {% load markdownify %}
 {% block content %}
     <div class="p-5 bg-body-tertiary">
-        <div class="row">
-            <div class="col-12 col-md-8 offset-md-2">
-                <h1>{{ packet_file.name }}</h1>
-                {% if packet_file.description %}<div class="mb-4">{{ packet_file.description|markdownify }}</div>{% endif %}
+        <div class="mx-auto" style="max-width: 640px;">
+            <h1>{{ packet_file.name }}</h1>
+            {% if packet_file.description %}<div class="mb-4">{{ packet_file.description|markdownify }}</div>{% endif %}
+            {% if display_code %}
                 <div class="alert alert-success">
                     <h4>Your Packet Item Code</h4>
                     <div class="code-display p-3 bg-white border rounded text-center mb-3">
-                        <code style="font-size: 1.5rem; font-weight: bold;">{{ display_code }}</code>
+                        <code class="user-select-all" style="font-size: 1.5rem; font-weight: bold;">{{ display_code }}</code>
                     </div>
                     <div class="text-center">
                         <button id="copy-button"
@@ -43,9 +43,19 @@
                     <strong>Note:</strong> This code is unique to you. You can access it again at any time by returning to this page.
                     You have viewed this code {{ access_count }} time{{ access_count|pluralize }}.
                 </div>
-                <a href="{% url 'hugopacket:election_packet' election_id=packet_file.packet.election.slug %}"
-                   class="btn btn-primary">Back to Packet</a>
-            </div>
+            {% else %}
+                <div class="mb-4 alert alert-light">
+                    <p><strong>The number of codes is limited.</strong> Please only claim a code if you don't already have access to the item and intend to use it.</p>
+                    <form method="post" action="{% url 'hugopacket:claim_code' election_id=packet_file.packet.election.slug packet_file_id=packet_file.id %}">
+                        {% csrf_token %}
+                        <button class="btn btn-primary" type="submit">
+                            <i class="fas fa-key"></i> Claim Code
+                        </button>
+                    </form>
+                </div>
+            {% endif %}
+            <a href="{% url 'hugopacket:election_packet' election_id=packet_file.packet.election.slug %}"
+                class="btn btn-primary">Back to Packet</a>
         </div>
     </div>
 {% endblock %}

--- a/src/nomnom/hugopacket/tests/test_models_and_views.py
+++ b/src/nomnom/hugopacket/tests/test_models_and_views.py
@@ -552,7 +552,7 @@ class TestPacketViews:
         assert "Finalist Name" in str(response.content)
 
     def test_download_code_assignment(self, client, user, member, packet):
-        """Test that accessing a code file assigns a code."""
+        """Test that posting to claim_code assigns a code and redirects to download_packet."""
         client.force_login(user)
 
         file = PacketFile.objects.create(
@@ -569,12 +569,22 @@ class TestPacketViews:
             code="TEST-CODE-1234",
         )
 
-        url = reverse(
+        generate_url = reverse(
+            "hugopacket:claim_code",
+            kwargs={"election_id": packet.election.slug, "packet_file_id": file.id},
+        )
+        response = client.post(generate_url)
+
+        # claim_code should redirect to download_packet
+        assert response.status_code == 302
+        download_url = reverse(
             "hugopacket:download_packet",
             kwargs={"election_id": packet.election.slug, "packet_file_id": file.id},
         )
-        response = client.get(url)
+        assert response["Location"] == download_url
 
+        # Following the redirect should show the code
+        response = client.get(download_url)
         assert response.status_code == 200
         assert "TEST-CODE-1234" in str(response.content)
 
@@ -586,6 +596,97 @@ class TestPacketViews:
         access = PacketItemAccess.objects.get(packet_file=file, member=member)
         assert access.distribution_code == code
         assert access.access_count == 1
+
+    def test_claim_code_requires_login(self, client, packet):
+        """Test that claim_code requires login."""
+        file = PacketFile.objects.create(
+            packet=packet,
+            name="Game Code",
+            access_type=PacketFile.AccessType.CODE,
+            s3_object_key="",
+            position=0,
+        )
+
+        url = reverse(
+            "hugopacket:claim_code",
+            kwargs={"election_id": packet.election.slug, "packet_file_id": file.id},
+        )
+        response = client.post(url)
+
+        assert response.status_code == 302
+        assert "login" in response.url
+
+    def test_claim_code_no_codes_available(self, client, user, member, packet):
+        """Test that claim_code returns 503 when no codes are available."""
+        client.force_login(user)
+
+        file = PacketFile.objects.create(
+            packet=packet,
+            name="Game Code",
+            access_type=PacketFile.AccessType.CODE,
+            s3_object_key="",
+            position=0,
+        )
+
+        url = reverse(
+            "hugopacket:claim_code",
+            kwargs={"election_id": packet.election.slug, "packet_file_id": file.id},
+        )
+        response = client.post(url)
+
+        assert response.status_code == 503
+
+    def test_claim_code_idempotent(self, client, user, member, packet):
+        """Test that posting claim_code again does not reassign the code."""
+        client.force_login(user)
+
+        file = PacketFile.objects.create(
+            packet=packet,
+            name="Game Code",
+            access_type=PacketFile.AccessType.CODE,
+            s3_object_key="",
+            position=0,
+        )
+
+        DistributionCode.objects.create(packet_file=file, code="FIRST-CODE")
+        DistributionCode.objects.create(packet_file=file, code="SECOND-CODE")
+
+        url = reverse(
+            "hugopacket:claim_code",
+            kwargs={"election_id": packet.election.slug, "packet_file_id": file.id},
+        )
+        client.post(url)
+
+        first_code = PacketItemAccess.objects.get(
+            packet_file=file, member=member
+        ).distribution_code
+
+        client.post(url)
+
+        second_code = PacketItemAccess.objects.get(
+            packet_file=file, member=member
+        ).distribution_code
+
+        assert first_code == second_code
+
+    def test_claim_code_invalid_for_download_type(self, client, user, member, packet):
+        """Test that claim_code returns 404 for non-code access type files."""
+        client.force_login(user)
+
+        file = PacketFile.objects.create(
+            packet=packet,
+            name="Download File",
+            access_type=PacketFile.AccessType.DOWNLOAD,
+            s3_object_key="some/key.pdf",
+            position=0,
+        )
+
+        url = reverse(
+            "hugopacket:claim_code",
+            kwargs={"election_id": packet.election.slug, "packet_file_id": file.id},
+        )
+        response = client.post(url)
+        assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/src/nomnom/hugopacket/urls.py
+++ b/src/nomnom/hugopacket/urls.py
@@ -11,4 +11,9 @@ urlpatterns = [
         views.download_packet,
         name="download_packet",
     ),
+    path(
+        "<election_id>/<int:packet_file_id>/claim_code/",
+        views.claim_code,
+        name="claim_code",
+    ),
 ]

--- a/src/nomnom/hugopacket/views.py
+++ b/src/nomnom/hugopacket/views.py
@@ -9,6 +9,7 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Prefetch
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseForbidden
+from django.views.decorators.http import require_POST
 from django.shortcuts import get_object_or_404, redirect, render, resolve_url
 from django.utils import timezone
 from waffle.decorators import waffle_switch
@@ -202,54 +203,16 @@ def download_packet(
             packet_file=packet_file, member=member
         )
 
-        # Assign a code if not already assigned
-        if not access.distribution_code:
-            with transaction.atomic():
-                # Get IDs of already assigned codes
-                assigned_code_ids = PacketItemAccess.objects.filter(
-                    distribution_code__packet_file=packet_file
-                ).values_list("distribution_code_id", flat=True)
+        if access.distribution_code:
+            # Record the access
+            access.increment_access()
 
-                # Find an unassigned code from the pool
-                unassigned_code = (
-                    DistributionCode.objects.filter(packet_file=packet_file)
-                    .exclude(id__in=assigned_code_ids)
-                    .select_for_update()
-                    .first()
-                )
-
-                if not unassigned_code:
-                    logger.error(
-                        "no distribution codes available",
-                        packet_file_id=packet_file.id,
-                        member_id=member.id,
-                    )
-                    return render(
-                        request,
-                        "hugopacket/no_codes_available.html",
-                        {"packet_file": packet_file},
-                        status=503,
-                    )
-
-                # Assign the code
-                access.distribution_code = unassigned_code
-                unassigned_code.assigned_at = timezone.now()
-                unassigned_code.save(update_fields=["assigned_at"])
-                access.save(update_fields=["distribution_code"])
-
-                logger.info(
-                    "assigned distribution code",
-                    packet_file_id=packet_file.id,
-                    member_id=member.id,
-                    code_id=unassigned_code.id,
-                )
-
-        # Record the access
-        access.increment_access()
-
-        # Format code for display and get raw version for copying
-        raw_code = access.distribution_code.code
-        display_code = packet_file.format_code(raw_code)
+            # Format code for display and get raw version for copying
+            raw_code = access.distribution_code.code
+            display_code = packet_file.format_code(raw_code)
+        else:
+            display_code = None
+            raw_code = None
 
         # Display the code to the user
         return render(
@@ -279,3 +242,86 @@ def download_packet(
 
     else:
         raise ValueError(f"Unknown access type: {packet_file.access_type}")
+
+
+@waffle_switch(SWITCH_HUGO_PACKET)
+@login_required
+@member_can_vote()
+@require_POST
+def claim_code(
+    request: HttpRequest, election_id: str, packet_file_id: int
+) -> HttpResponse:
+    election = get_object_or_404(Election, slug=election_id)
+    packet_file = get_object_or_404(PacketFile, pk=packet_file_id)
+    # ensure that the packet file belongs to the election
+    if packet_file.packet.election != election:
+        raise Http404()
+
+    if not packet_file.packet.enabled and not request.user.has_perm(
+        "hugopacket.preview_packet"
+    ):
+        raise Http404()
+
+    if not packet_file.available:
+        return HttpResponseForbidden()
+
+    # Handle code-based access
+    if packet_file.access_type != PacketFile.AccessType.CODE:
+        raise Http404("Invalid access type for code generation.")
+
+    # Get member profile (required for tracking access)
+    member = request.user.convention_profile
+
+    with transaction.atomic():
+        # Get or create access record
+        access, created = PacketItemAccess.objects.get_or_create(
+            packet_file=packet_file, member=member
+        )
+
+        # Assign a code if not already assigned
+        if not access.distribution_code:
+            # Get IDs of already assigned codes
+            assigned_code_ids = PacketItemAccess.objects.filter(
+                distribution_code__packet_file=packet_file
+            ).values_list("distribution_code_id", flat=True)
+
+            # Find an unassigned code from the pool
+            unassigned_code = (
+                DistributionCode.objects.filter(packet_file=packet_file)
+                .exclude(id__in=assigned_code_ids)
+                .select_for_update()
+                .first()
+            )
+
+            if not unassigned_code:
+                logger.error(
+                    "no distribution codes available",
+                    packet_file_id=packet_file.id,
+                    member_id=member.id,
+                )
+                return render(
+                    request,
+                    "hugopacket/no_codes_available.html",
+                    {"packet_file": packet_file},
+                    status=503,
+                )
+
+            # Assign the code
+            access.distribution_code = unassigned_code
+            unassigned_code.assigned_at = timezone.now()
+            unassigned_code.save(update_fields=["assigned_at"])
+            access.save(update_fields=["distribution_code"])
+
+            logger.info(
+                "assigned distribution code",
+                packet_file_id=packet_file.id,
+                member_id=member.id,
+                code_id=unassigned_code.id,
+            )
+
+    # Redirect to the download page
+    return redirect(
+        "hugopacket:download_packet",
+        election_id=election.slug,
+        packet_file_id=packet_file.id,
+    )


### PR DESCRIPTION
Previously clicking on the link to view the code would claim it. This made it too easy to accidentally claim a code if you were just trying to explore what was on offer.

This patch adds an explicit "Claim Code" button that makes it harder to accidentaly claim the code.

This allows us to move the caveat about only claiming if needed from the packet list screen to the code screen, tidying up the packet list.

This patch also fixes a bug in the code generation where the check for whether they already had a code wasn't in the same transaction that allocated the code, meaning two parallel requests could assign two codes.

I took the opportunity to add a couple of minor UX improvements:
 * Remove the underline on the space between the link the "code" badge
 * Made it so the browser selects the entire code when clicking on it

<img width="1320" height="786" alt="image" src="https://github.com/user-attachments/assets/dadcc4ed-7e18-4722-86af-6448f190ac80" />

Fixes #417