### PR TITLE
bugfix: htmx support when no codes are available

### DIFF
--- a/src/nomnom/hugopacket/templates/hugopacket/display_code.html
+++ b/src/nomnom/hugopacket/templates/hugopacket/display_code.html
@@ -26,10 +26,13 @@
                         </div>
                     {% else %}
                         <div class="alert alert-success">
-                            <button hx-post="{% url 'hugopacket:claim_code' election_id=packet_file.packet.election.slug packet_file_id=packet_file.id %}"
-                                    hx-target="closest div"
-                                    hx-swap="innerHTML"
-                                    class="btn btn-primary">Claim Code</button>
+                            <form method="post" action="{% url 'hugopacket:claim_code' election_id=packet_file.packet.election.slug packet_file_id=packet_file.id %}">
+                                {% csrf_token %}
+                                <button hx-post="{% url 'hugopacket:claim_code' election_id=packet_file.packet.election.slug packet_file_id=packet_file.id %}"
+                                        hx-target="closest .alert"
+                                        hx-swap="innerHTML"
+                                        class="btn btn-primary">Claim Code</button>
+                            </form>
                         </div>
                     {% endif %}
                 {% endblock display_code %}
@@ -52,7 +55,6 @@
                 </script>
                 <div class="alert alert-info">
                     <strong>Note:</strong> This code is unique to you. You can access it again at any time by returning to this page.
-                    You have viewed this code {{ access_count }} time{{ access_count|pluralize }}.
                 </div>
                 <a href="{% url 'hugopacket:election_packet' election_id=packet_file.packet.election.slug %}"
                    class="btn btn-primary">Back to Packet</a>

--- a/src/nomnom/hugopacket/templates/hugopacket/no_codes_available.html
+++ b/src/nomnom/hugopacket/templates/hugopacket/no_codes_available.html
@@ -5,14 +5,16 @@
         <div class="row">
             <div class="col-12 col-md-8 offset-md-2">
                 <h1>No Codes Available</h1>
-                <div class="alert alert-warning">
-                    <h4>Publisher-provided codes unavailable</h4>
-                    <p>
-                        We're sorry, but there are currently no remaining publisher-provided codes available for
-                        <strong>{{ packet_file.name }}</strong>.
-                    </p>
-                    <p>Please check back later in case the publisher is able to provide more codes.</p>
-                </div>
+                {% block display_code %}
+                    <div class="alert alert-warning">
+                        <h4>Publisher-provided codes unavailable</h4>
+                        <p>
+                            We're sorry, but there are currently no remaining publisher-provided codes available for
+                            <strong>{{ packet_file.name }}</strong>.
+                        </p>
+                        <p>Please check back later in case the publisher is able to provide more codes.</p>
+                    </div>
+                {% endblock display_code %}
                 {% if packet_file.description %}
                     <div class="mb-4">
                         <h5>About this item:</h5>

--- a/src/nomnom/hugopacket/views.py
+++ b/src/nomnom/hugopacket/views.py
@@ -300,10 +300,19 @@ def claim_code(
                     packet_file_id=packet_file.id,
                     member_id=member.id,
                 )
+                template_name = "hugopacket/no_codes_available.html"
+                context_data = {"packet_file": packet_file}
+                if request.htmx:
+                    return HttpResponse(
+                        render_block_to_string(
+                            template_name, "display_code", context_data, request
+                        )
+                    )
+
                 return render(
                     request,
-                    "hugopacket/no_codes_available.html",
-                    {"packet_file": packet_file},
+                    template_name,
+                    context_data,
                     status=503,
                 )
 
@@ -322,7 +331,7 @@ def claim_code(
 
     if request.htmx:
         # render the template fragment for the code only
-        template_name = ("hugopacket/display_code.html",)
+        template_name = "hugopacket/display_code.html"
         context_data = {
             "packet_file": packet_file,
             "display_code": packet_file.format_code(access.distribution_code.code),


### PR DESCRIPTION
The 503 error when no code is available was being suppressed when HTMX actions are used. 