### PR TITLE
vote counting: tie breakers now handle first places correctly

### DIFF
--- a/src/nomnom/wsfs/rules/constitution_2023.py
+++ b/src/nomnom/wsfs/rules/constitution_2023.py
@@ -1,4 +1,5 @@
 import math
+from collections import Counter
 from dataclasses import dataclass
 from itertools import groupby
 from operator import attrgetter
@@ -70,6 +71,16 @@ def hugo_voting(
         if maybe_no_award:
             runoff_candidate = maybe_no_award[0]
 
+    # For later tiebreaking, compute the number of first place votes for each candidate
+    first_places = Counter({c: 0 for c in candidates})
+    for ballot in ballots:
+        first_places[ballot.ranked_candidates[0]] += 1
+
+    logger.debug(
+        "First place tallies",
+        first_places={c.name: v for c, v in first_places.items()},
+    )
+
     manager = ElectionManager(
         candidates,
         ballots,
@@ -139,18 +150,23 @@ def hugo_voting(
             votes_remaining -= votes_for_finalist
             log = log.bind(votes_remaining=votes_remaining)
 
-        # reject the finalist with the fewest votes.
-        # if there are multiple candidates with the same number of votes, reject them all.
-        # pyrankvote doesn't actually handle ties for last place, so we
-        # have to do it ourselves. This involves pyrankvote internals.
+        # * reject the finalist with the fewest votes.
+        # * if there are multiple candidates with the same number of votes,
+        #   reject the one that had the fewest original first place voces.
+        # * if there are multiple candidates tied for fewest votes and
+        #   fewest first place votes, reject them all.
+        #
+        # pyrankvote doesn't actually handle ties for last place, so we have to do it ourselves.
+        # This involves pyrankvote internals.
         assert len(manager._candidates_in_race) > 0, (
             "Can't get here without some candidates left"
         )
-        last_place_vote_count = manager._candidates_in_race[-1].number_of_votes
+        candidate_vc_with_least_votes = all_min(
+            manager._candidates_in_race, key=lambda vc: vc.number_of_votes
+        )
+        last_place_vote_count = candidate_vc_with_least_votes[0].number_of_votes
         candidates_with_least_votes = [
-            vc.candidate
-            for vc in manager._candidates_in_race
-            if vc.number_of_votes == last_place_vote_count
+            vc.candidate for vc in candidate_vc_with_least_votes
         ]
         log.debug(
             "Checking tiebreak counts",
@@ -158,7 +174,14 @@ def hugo_voting(
             candidates_with_least_votes=len(candidates_with_least_votes),
         )
 
-        for candidate in candidates_with_least_votes:
+        first_place_tiebreak = all_min(
+            candidates_with_least_votes, key=lambda c: first_places[c]
+        )
+        log.debug(
+            "First place tiebreak", candidates=[c.name for c in first_place_tiebreak]
+        )
+
+        for candidate in first_place_tiebreak:
             if candidate not in finalists_to_elect:
                 log.debug(
                     "Propose to reject as last place",
@@ -438,3 +461,10 @@ def nominations_for_elimination(counts: dict[str, CountData]) -> list[str]:
     fewest_points = nominations_with_fewest_points(counts)
     fewest_nominations = nominations_with_fewest_nominations(fewest_points)
     return list(fewest_nominations.keys())
+
+
+def all_min(iterable, key=lambda x: x) -> list:
+    """Return a list of all items in the iterable that are tied for minimum value."""
+    sorted_items = sorted(iterable, key=key)
+    min_value = key(sorted_items[0])
+    return [item for item in sorted_items if key(item) == min_value]

--- a/src/nomnom/wsfs/tests/test_constitution_2023.py
+++ b/src/nomnom/wsfs/tests/test_constitution_2023.py
@@ -1,3 +1,5 @@
+from typing import Set
+
 import pytest
 from pyrankvote import Ballot, Candidate
 from pyrankvote.helpers import CandidateStatus
@@ -179,3 +181,49 @@ class TestEdgeCases:
                 assert cr.number_of_votes == 11, (
                     f"Unexpected vote count for {cr.candidate}"
                 )
+
+    def test_when_tied_for_elimination_use_first_place_votes_as_tiebreaker(self):
+        """Don't eliminate all bottom candidates automatically.
+
+        When candidates are tied for elimination, the candidate with the fewest first-place votes
+        should be eliminated.
+
+        """
+        a = Candidate("Candidate A")
+        b = Candidate("Candidate B")
+        c = Candidate("Candidate C")
+        d = Candidate("Candidate D")
+        e = Candidate("Candidate E")
+        f = Candidate("Candidate F")
+        no_award = Candidate("No Award")
+
+        candidates = [a, b, c, d, e, f, no_award]
+
+        # Craft a scenario where the two candidates with the fewest votes are tied, but one has fewer first-place votes and should be eliminated.
+        # In this case, after eliminating a candidate, two are now tied with their votes transferred, but the tiebreaker should still be applied correctly.
+        # So, we need realistic ballots that would lead to this scenario:
+        ballots = [
+            *[Ballot([a]) for _ in range(6)],  # A: 6 first-place
+            *[Ballot([b]) for _ in range(5)],  # B: 5 first-place
+            *[Ballot([c]) for _ in range(4)],  # C: 4 first-place
+            *[Ballot([e]) for _ in range(3)],  # E: 3 first-place (no transfers)
+            *[Ballot([d]) for _ in range(2)],  # D: 2 first-place (no transfers)
+            Ballot([f, d]),  # F: 1 first-place, transfers to D
+            # No Award: 0 first-place
+        ]
+        results = hugo_voting(candidates, ballots, runoff_candidate=no_award)
+
+        # No award is eliminated first,then D; the next round is our test round.
+        elimination_round = results.rounds[2]
+
+        def rejected(round) -> Set[Candidate]:
+            return set(
+                cr.candidate
+                for cr in round.candidate_results
+                if cr.status == CandidateStatus.Rejected
+            )
+
+        ignored_eliminations = rejected(results.rounds[0]) | rejected(results.rounds[1])
+        assert rejected(elimination_round) - ignored_eliminations == {d}, (
+            f"Unexpected rejected candidates: {rejected(elimination_round)}"
+        )


### PR DESCRIPTION
Specifically, this part of the algorithm was not quite computed correctly:

"Else if more than one candidate has the fewest remaining votes, eliminate all such candidates who had the fewest first-round votes"

The eliminations were catching multiple in one round.