### PR TITLE
Make packet item table sortable by access stats (number of members)

### DIFF
--- a/src/nomnom/hugopacket/admin.py
+++ b/src/nomnom/hugopacket/admin.py
@@ -194,8 +194,15 @@ class PacketFileAdmin(AdminActionFormsMixin, PrefillSingleton, admin.ModelAdmin)
     actions = [assign_section]
     singleton_initial_fields = ["packet"]
 
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        queryset = queryset.annotate(
+            _member_access_count=django_models.aggregates.Count("member_accesses", distinct=True),
+        )
+        return queryset
+
     def access_stats(self, obj):
-        count = obj.member_accesses.count()
+        count = obj._member_access_count
         total_accesses = (
             obj.member_accesses.aggregate(total=django_models.Sum("access_count"))[
                 "total"
@@ -205,6 +212,7 @@ class PacketFileAdmin(AdminActionFormsMixin, PrefillSingleton, admin.ModelAdmin)
         return "{} members ({} total)".format(count, total_accesses)
 
     access_stats.short_description = "Access Stats"
+    access_stats.admin_order_field = "_member_access_count"
 
     def available_codes(self, obj):
         if obj.access_type == models.PacketFile.AccessType.CODE:

--- a/src/nomnom/hugopacket/admin.py
+++ b/src/nomnom/hugopacket/admin.py
@@ -197,7 +197,9 @@ class PacketFileAdmin(AdminActionFormsMixin, PrefillSingleton, admin.ModelAdmin)
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
         queryset = queryset.annotate(
-            _member_access_count=django_models.aggregates.Count("member_accesses", distinct=True),
+            _member_access_count=django_models.aggregates.Count(
+                "member_accesses", distinct=True
+            ),
         )
         return queryset
 


### PR DESCRIPTION
This is a simple change to make the "Access Stats" field in the packet item table sortable

Disclaimer: i'm not very knowledgeable about Django - i got this syntax from https://books.agiliq.com/projects/django-admin-cookbook/en/latest/sorting_calculated_fields.html

It appears to work on my local site:

<img width="839" height="425" alt="sort_by_access_stats" src="https://github.com/user-attachments/assets/f5aace0e-8e59-4ea2-80cf-b2093da54b54" />
