### PR TITLE
Decouple nominate tests from view implementation style

### DIFF
--- a/src/nomnom/nominate/tests/test_reports.py
+++ b/src/nomnom/nominate/tests/test_reports.py
@@ -4,8 +4,8 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser, Permission
-from django.test import RequestFactory
+from django.contrib.auth.models import Permission
+from django.urls import reverse
 from freezegun import freeze_time
 from nomnom.nominate import factories, models, reports
 
@@ -19,6 +19,7 @@ def make_user(db):
     user.is_staff = True
     perm = Permission.objects.get(codename="report")
     user.user_permissions.add(perm)
+    user.save()
     return user
 
 
@@ -98,40 +99,27 @@ def make_nomination(db, user, category):
     return factories.NominationFactory(nominator=nominator, category=category)
 
 
-@pytest.fixture
-def request_factory():
-    return RequestFactory()
+@pytest.fixture(name="report_url")
+def make_report_url():
+    return reverse(
+        "election:nomination-report", kwargs={"election_id": "election_slug"}
+    )
 
 
-@pytest.fixture(name="http_request")
-def make_http_request(request_factory, user):
-    request = request_factory.get("/nominations/", HTTP_ACCEPT="text/csv")
-    request.user = user
-    return request
-
-
-@pytest.fixture(name="unauthenticated_request")
-def make_unauthenticated_request(request_factory):
-    request = request_factory.get("/nominations/", HTTP_ACCEPT="text/csv")
-    request.user = AnonymousUser()
-    return request
-
-
-@pytest.fixture(name="nominations_view")
-def make_nominations_view():
-    view = reports.Nominations()
-    view.kwargs = {"election_id": "election_slug"}
-    return view
-
-
-def test_nomination_view_dispatch(http_request, nominations_view, nomination):
-    response = nominations_view.dispatch(http_request)
+def test_nomination_view_dispatch(client, report_url, user, nomination):
+    client.force_login(user)
+    response = client.get(report_url, HTTP_ACCEPT="text/csv")
     assert response.status_code == 200
     assert response["Content-Type"] == "text/csv"
 
 
-def test_nomination_view_election(nominations_view, election):
-    assert nominations_view.election() == election
+def test_nomination_view_unknown_election_returns_404(client, user):
+    client.force_login(user)
+    url = reverse(
+        "election:nomination-report", kwargs={"election_id": "does-not-exist"}
+    )
+    response = client.get(url, HTTP_ACCEPT="text/csv")
+    assert response.status_code == 404
 
 
 def test_nomination_report_query_set(nominations_report, nomination):
@@ -139,26 +127,25 @@ def test_nomination_report_query_set(nominations_report, nomination):
     assert queryset == [nomination]
 
 
-def test_nomination_view_dispatch_unauthenticated(
-    unauthenticated_request, nominations_view
-):
-    response = nominations_view.dispatch(unauthenticated_request)
+def test_nomination_view_dispatch_unauthenticated(client, report_url):
+    response = client.get(report_url, HTTP_ACCEPT="text/csv")
     assert response.status_code == 302
     parts = urlparse(response.url)
     query = parse_qs(parts.query)
-    assert query["next"][0] == unauthenticated_request.path
+    assert query["next"][0] == report_url
 
 
-def test_nomination_view_get_unauthenticated(nominations_view, unauthenticated_request):
-    response = nominations_view.get(unauthenticated_request)
+def test_nomination_view_get_unauthenticated(client, report_url):
+    response = client.get(report_url, HTTP_ACCEPT="text/csv")
     assert response.status_code == 302
     parts = urlparse(response.url)
     query = parse_qs(parts.query)
-    assert query["next"][0] == unauthenticated_request.path
+    assert query["next"][0] == report_url
 
 
-def test_nomination_view_get(http_request, nominations_view, nomination):
-    response = nominations_view.get(http_request)
+def test_nomination_view_get(client, report_url, user, nomination):
+    client.force_login(user)
+    response = client.get(report_url, HTTP_ACCEPT="text/csv")
 
     assert response.status_code == 200
 
@@ -168,7 +155,7 @@ def test_nomination_view_get(http_request, nominations_view, nomination):
     header = next(reader)
     expected_header = [
         field.name for field in models.Nomination._meta.fields
-    ] + nominations_view.report().extra_fields
+    ] + reports.NominationsReport.extra_fields
     assert header == expected_header
 
     content = StringIO(response.content.decode())

--- a/src/nomnom/nominate/tests/test_views.py
+++ b/src/nomnom/nominate/tests/test_views.py
@@ -1,60 +1,84 @@
 import itertools
 from collections.abc import Iterable
-from unittest.mock import Mock
 
 import pytest
-from django.contrib.auth.models import AnonymousUser, Permission
+from django.contrib.auth.models import Permission
 from django.core import mail
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 from django.urls import reverse
 
 from nomnom.nominate import factories, models
-from nomnom.nominate.views import (
-    ElectionModeView,
-    ElectionView,
-    NominationView,
-)
 
 pytestmark = pytest.mark.usefixtures("db")
 
 
 class TestElectionView(TestCase):
     def setup_method(self, test_method):
-        self.request_factory = RequestFactory()
         self.member = factories.NominatingMemberProfileFactory.create()
         self.user = self.member.user
 
     def test_get_queryset(self):
-        request = self.request_factory.get("/")
-        request.user = self.user
-        response = ElectionView.as_view()(request)
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("election:index"))
         assert response.status_code == 200
 
 
 class TestElectionModeView(TestCase):
     def setup_method(self, test_method):
         self.election = factories.ElectionFactory.create()
-        self.request_factory = RequestFactory()
         self.member = factories.NominatingMemberProfileFactory.create()
         self.user = self.member.user
 
-    def test_get_redirect_url_nominate(self):
-        self.election.user_can_nominate = Mock(return_value=True)
-        request = self.request_factory.get("/")
-        request.user = self.user
-        response = ElectionModeView.as_view()(request, election_id=self.election.slug)
+    def redirect_url(self):
+        return reverse("election:redirect", kwargs={"election_id": self.election.slug})
+
+    def grant(self, codename):
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename=codename, content_type__app_label="nominate"
+            )
+        )
+
+    def test_get_nominating_redirect_url(self):
+        self.election.state = models.Election.STATE.NOMINATIONS_OPEN
+        self.election.save()
+        self.grant("nominate")
+        self.client.force_login(self.user)
+        response = self.client.get(self.redirect_url())
+        expected_url = reverse(
+            "election:nominate", kwargs={"election_id": self.election.slug}
+        )
+        assert response.status_code == 302
+        assert response.url == expected_url
+
+    def test_get_nominating_redirect_url_without_rights(self):
+        self.election.state = models.Election.STATE.NOMINATIONS_OPEN
+        self.election.save()
+        self.client.force_login(self.user)
+        response = self.client.get(self.redirect_url())
         expected_url = reverse(
             "election:closed", kwargs={"election_id": self.election.slug}
         )
         assert response.status_code == 302
         assert response.url == expected_url
 
-    def test_get_redirect_url_vote(self):
-        self.election.user_can_nominate = Mock(return_value=False)
-        self.election.user_can_vote = Mock(return_value=True)
-        request = self.request_factory.get("/")
-        request.user = self.user
-        response = ElectionModeView.as_view()(request, election_id=self.election.slug)
+    def test_get_voting_redirect_url(self):
+        self.election.state = models.Election.STATE.VOTING
+        self.election.save()
+        self.grant("vote")
+        self.client.force_login(self.user)
+        response = self.client.get(self.redirect_url())
+        expected_url = reverse(
+            "election:vote", kwargs={"election_id": self.election.slug}
+        )
+        assert response.status_code == 302
+        assert response.url == expected_url
+
+    def test_get_voting_redirect_url_without_rights(self):
+        self.election.state = models.Election.STATE.VOTING
+        self.election.save()
+        self.client.force_login(self.user)
+        response = self.client.get(self.redirect_url())
         expected_url = reverse(
             "election:closed", kwargs={"election_id": self.election.slug}
         )
@@ -62,11 +86,10 @@ class TestElectionModeView(TestCase):
         assert response.url == expected_url
 
     def test_get_redirect_url_closed(self):
-        self.election.user_can_nominate = Mock(return_value=False)
-        self.election.user_can_vote = Mock(return_value=False)
-        request = self.request_factory.get("/")
-        request.user = self.user
-        response = ElectionModeView.as_view()(request, election_id=self.election.slug)
+        self.election.state = models.Election.STATE.PRE_NOMINATION
+        self.election.save()
+        self.client.force_login(self.user)
+        response = self.client.get(self.redirect_url())
         expected_url = reverse(
             "election:closed", kwargs={"election_id": self.election.slug}
         )
@@ -76,7 +99,6 @@ class TestElectionModeView(TestCase):
 
 class TestClosedElectionView(TestCase):
     def setup_method(self, test_method):
-        self.request_factory = RequestFactory()
         self.election = factories.ElectionFactory.create(
             state=models.Election.STATE.NOMINATIONS_CLOSED
         )
@@ -150,7 +172,6 @@ class NominationViewInvariants(TestCase):
 
     def setup_method(self, test_method):
         self.election = factories.ElectionFactory.create(state="nominating")
-        self.request_factory = RequestFactory()
         self.member = factories.NominatingMemberProfileFactory.create()
         self.user = self.member.user
         self.user.user_permissions.add(
@@ -170,16 +191,14 @@ class NominationViewInvariants(TestCase):
         )
 
     def test_get_anonymous(self):
-        request = self.request_factory.get("/")
-        request.user = AnonymousUser()
-        response = self.view_class.as_view()(request, election_id="dummy-election-id")
+        url = self.view_url()
+        response = self.client.get(url)
         assert response.status_code == 302
-        assert response.url == f"{reverse('login')}?next=/"
+        assert response.url == f"{reverse('login')}?next={url}"
 
     def test_get_form(self):
-        request = self.request_factory.get("/")
-        request.user = self.user
-        response = self.view_class.as_view()(request, election_id=self.election.slug)
+        self.client.force_login(self.user)
+        response = self.client.get(self.view_url())
         assert response.status_code == 200
 
     def test_submitting_valid_data_does_not_remove_other_members_nominations(self):
@@ -326,7 +345,6 @@ class NominationViewInvariants(TestCase):
 
 class TestNominationViewFull(NominationViewInvariants, NominationViewSubmitMixin):
     __test__ = True
-    view_class = NominationView
     success_status_code = 302
 
     def view_url(self):
@@ -335,7 +353,6 @@ class TestNominationViewFull(NominationViewInvariants, NominationViewSubmitMixin
 
 class TestNominationViewHTMX(NominationViewInvariants, NominationHTMXSubmitMixin):
     __test__ = True
-    view_class = NominationView
     success_status_code = 200
 
     def view_url(self):
@@ -345,7 +362,6 @@ class TestNominationViewHTMX(NominationViewInvariants, NominationHTMXSubmitMixin
 class TestAdminNominationView(TestCase):
     def setup_method(self, test_method):
         self.election = factories.ElectionFactory(state="nominating")
-        self.request_factory = RequestFactory()
         self.member = factories.NominatingMemberProfileFactory.create()
         staff_user = factories.UserFactory.create(is_staff=True)
         self.staff = factories.NominatingMemberProfileFactory.create(user=staff_user)

--- a/src/nomnom/nominate/tests/test_views_vote.py
+++ b/src/nomnom/nominate/tests/test_views_vote.py
@@ -6,7 +6,6 @@ from django.http import HttpResponse
 from pytest_lazy_fixtures import lf
 
 from nomnom.nominate import factories, models
-from nomnom.nominate.views.vote import VoteView
 
 # mark all tests in the module with @pytest.mark.django_db
 pytestmark = pytest.mark.django_db
@@ -27,13 +26,6 @@ with_submitters = pytest.mark.parametrize(
         lf("submit_votes_http"),
     ],
 )
-
-full_page_only = pytest.mark.parametrize("view_class", [lf("full_page_view")])
-
-
-@pytest.fixture(name="full_page_view")
-def full_page_view_class():
-    return VoteView
 
 
 def basic_ranks(c: models.Category) -> dict[str, list[int]]:


### PR DESCRIPTION
Refactor the nominate test suite so the view tests exercise behaviour through URL routing + the Django test client rather than reaching into view internals. The tests no longer care whether a view is a function-based view or a class-based view.

Previously several tests were coupled to the CBV implementation:

- test_views.py imported view classes and invoked `SomeView.as_view()(request)` directly via RequestFactory, and used a `view_class` attribute on test subclasses.
- test_reports.py instantiated `reports.Nominations()`, set `.kwargs` by hand, and called `.dispatch()` / `.get()` / `.election()` / `.report()` instance methods directly.
- test_views_vote.py imported `VoteView` and defined an unused `view_class` parametrize fixture (dead code).

Changes:

- All view tests now use `reverse()` + `self.client` / the pytest-django `client` fixture, asserting on HTTP status / redirect targets / response bodies instead of view objects.
- TestElectionModeView now drives the redirect logic by setting real election states and granting real permissions, instead of mocking `user_can_nominate`/`user_can_vote` on a model instance that the view re-fetched (those mocks were silently ineffective).
- Removed dead view-class imports/fixtures from test_views_vote.py.
- Fixed the `user` fixture in test_reports.py to persist `is_staff=True` (it was only set in memory, which broke once auth goes through the client instead of a hand-built RequestFactory request).

Verified style-agnosticism by temporarily converting ElectionModeView to a function-based view: the tests pass unchanged against both forms.

No production code changed; only tests.