### PR TITLE
Refactor class-based views into function-based views

### DIFF
--- a/src/nomnom/nominate/templates/nominate/election_list.html
+++ b/src/nomnom/nominate/templates/nominate/election_list.html
@@ -12,7 +12,7 @@
                     {% endif %}
                 </div>
             </div>
-            {% for election in object_list %}
+            {% for election in election_list %}
                 {% if forloop.first %}<div class="list-group justify-content-center col-md-6">{% endif %}
                     {% include "nominate/_election_list_entry.html" with election=election %}
                     {% if forloop.last %}</div>{% endif %}

--- a/src/nomnom/nominate/tests/test_views.py
+++ b/src/nomnom/nominate/tests/test_views.py
@@ -1,8 +1,10 @@
 import itertools
 from collections.abc import Iterable
+from unittest import mock
 
 import pytest
 from django.contrib.auth.models import Permission
+from django.contrib.messages import get_messages
 from django.core import mail
 from django.test import TestCase
 from django.urls import reverse
@@ -174,6 +176,11 @@ class NominationViewInvariants(TestCase):
         self.election = factories.ElectionFactory.create(state="nominating")
         self.member = factories.NominatingMemberProfileFactory.create()
         self.user = self.member.user
+        # The profile whose ballot is being edited. For the regular nominating
+        # views this is the logged-in member themselves; admin subclasses
+        # override this so the invariants run against a *different* member's
+        # ballot than the logged-in actor.
+        self.nominating_profile = self.member
         self.user.user_permissions.add(
             Permission.objects.get(
                 codename="nominate", content_type__app_label="nominate"
@@ -238,7 +245,7 @@ class NominationViewInvariants(TestCase):
         factories.NominationFactory.create_batch(
             2,
             category=self.c1,
-            nominator=self.user.convention_profile,
+            nominator=self.nominating_profile,
         )
         assert models.Nomination.objects.count() == 2
         valid_data = {
@@ -338,9 +345,9 @@ class NominationViewInvariants(TestCase):
 
         self.submit_nominations(data)
 
-        assert self.user.convention_profile.nomination_set.count() == 3
-        assert self.user.convention_profile.nomination_set.first().field_1 == "title 1"
-        assert self.user.convention_profile.nomination_set.last().field_1 == "title 3"
+        assert self.nominating_profile.nomination_set.count() == 3
+        assert self.nominating_profile.nomination_set.first().field_1 == "title 1"
+        assert self.nominating_profile.nomination_set.last().field_1 == "title 3"
 
 
 class TestNominationViewFull(NominationViewInvariants, NominationViewSubmitMixin):
@@ -357,6 +364,61 @@ class TestNominationViewHTMX(NominationViewInvariants, NominationHTMXSubmitMixin
 
     def view_url(self):
         return reverse("election:nominate", kwargs={"election_id": self.election.slug})
+
+
+class AdminNominationInvariants(NominationViewInvariants):
+    """Run the shared ballot-submission invariants against the admin edit view.
+
+    The logged-in actor is a staff member with the ``edit_ballot`` permission,
+    while the ballot being edited belongs to a *different* member
+    (``self.member``). This ensures the admin view honours the same
+    save/clear/ordering/validation guarantees as the member-facing view.
+    """
+
+    __test__ = False
+
+    def setup_method(self, test_method):
+        self.election = factories.ElectionFactory.create(state="nominating")
+        # The member whose ballot is being edited by the admin.
+        self.member = factories.NominatingMemberProfileFactory.create()
+        self.nominating_profile = self.member
+
+        # The logged-in actor: a staff user with edit_ballot rights.
+        staff_user = factories.UserFactory.create(is_staff=True)
+        self.staff = factories.NominatingMemberProfileFactory.create(user=staff_user)
+        self.user = self.staff.user
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename="edit_ballot", content_type__app_label="nominate"
+            )
+        )
+
+        self.c1 = factories.CategoryFactory.create(
+            election=self.election,
+            fields=2,
+            ballot_position=1,
+        )
+        self.c2 = factories.CategoryFactory.create(
+            election=self.election,
+            fields=2,
+            ballot_position=2,
+        )
+
+    def view_url(self):
+        return reverse(
+            "election:edit_nominations",
+            kwargs={"election_id": self.election.slug, "member_id": self.member.id},
+        )
+
+
+class TestAdminNominationViewFull(AdminNominationInvariants, NominationViewSubmitMixin):
+    __test__ = True
+    success_status_code = 302
+
+
+class TestAdminNominationViewHTMX(AdminNominationInvariants, NominationHTMXSubmitMixin):
+    __test__ = True
+    success_status_code = 200
 
 
 class TestAdminNominationView(TestCase):
@@ -476,6 +538,138 @@ class TestAdminNominationView(TestCase):
         with self.captureOnCommitCallbacks(execute=True):
             self.submit_nominations(valid_data)
         assert len(mail.outbox) == 0
+
+
+class TestNominationViewOnCommit(TestCase):
+    """Exercise the post-commit side effects of submitting a ballot.
+
+    The existing invariant suites never run the ``transaction.on_commit``
+    callback (they don't wrap submission in ``captureOnCommitCallbacks``), so the
+    work scheduled there - linking nominations to works and running the
+    post-save hook - is entirely untested. These tests post to the member-facing
+    nominate view, execute the on-commit callbacks, and assert the observable
+    behaviour without reaching into the view's internals.
+    """
+
+    def setup_method(self, test_method):
+        self.election = factories.ElectionFactory.create(state="nominating")
+        self.member = factories.NominatingMemberProfileFactory.create()
+        self.user = self.member.user
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename="nominate", content_type__app_label="nominate"
+            )
+        )
+        self.c1 = factories.CategoryFactory.create(
+            election=self.election,
+            fields=2,
+            ballot_position=1,
+        )
+
+    def view_url(self):
+        return reverse("election:nominate", kwargs={"election_id": self.election.slug})
+
+    def valid_data(self):
+        return {
+            f"{self.c1.id}-0-field_1": "t1",
+            f"{self.c1.id}-0-field_2": "a1",
+        }
+
+    def test_submitting_triggers_link_nominations_to_works_task(self):
+        self.client.force_login(self.user)
+        with mock.patch(
+            "nomnom.nominate.tasks.link_nominations_to_works.delay"
+        ) as delay:
+            with self.captureOnCommitCallbacks(execute=True):
+                response = self.client.post(self.view_url(), data=self.valid_data())
+
+        assert response.status_code == 302
+        assert delay.called
+
+    def test_submitting_runs_post_save_hook(self):
+        self.client.force_login(self.user)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(self.view_url(), data=self.valid_data())
+
+        messages = [str(m) for m in get_messages(response.wsgi_request)]
+        assert any("Your set of nominations was saved" in m for m in messages)
+
+
+class TestNominationViewClosed(TestCase):
+    """When a member with nominating rights POSTs to an election whose
+    nominations have closed, the view rejects the submission with an error
+    message and saves nothing.
+    """
+
+    def setup_method(self, test_method):
+        self.election = factories.ElectionFactory.create(state="nominating_closed")
+        self.member = factories.NominatingMemberProfileFactory.create()
+        self.user = self.member.user
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename="nominate", content_type__app_label="nominate"
+            )
+        )
+        self.c1 = factories.CategoryFactory.create(
+            election=self.election,
+            fields=2,
+            ballot_position=1,
+        )
+
+    def view_url(self):
+        return reverse("election:nominate", kwargs={"election_id": self.election.slug})
+
+    def test_posting_to_closed_election_reports_closed(self):
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.view_url(),
+            data={
+                f"{self.c1.id}-0-field_1": "t1",
+                f"{self.c1.id}-0-field_2": "a1",
+            },
+        )
+
+        assert response.status_code == 302
+        messages = [str(m) for m in get_messages(response.wsgi_request)]
+        assert any("Nominations have closed" in m for m in messages)
+        assert models.Nomination.objects.count() == 0
+
+
+class TestAdminNominationViewGet(TestCase):
+    """The admin edit view renders the admin template on GET, even though the
+    logged-in staff actor has no nominating rights of their own.
+    """
+
+    def setup_method(self, test_method):
+        self.election = factories.ElectionFactory.create(state="nominating")
+        self.member = factories.NominatingMemberProfileFactory.create()
+
+        staff_user = factories.UserFactory.create(is_staff=True)
+        self.staff = factories.NominatingMemberProfileFactory.create(user=staff_user)
+        self.user = self.staff.user
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename="edit_ballot", content_type__app_label="nominate"
+            )
+        )
+        self.c1 = factories.CategoryFactory.create(
+            election=self.election,
+            fields=2,
+            ballot_position=1,
+        )
+
+    def view_url(self):
+        return reverse(
+            "election:edit_nominations",
+            kwargs={"election_id": self.election.slug, "member_id": self.member.id},
+        )
+
+    def test_get_renders_admin_template(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.view_url())
+
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "nominate/admin_nominate.html")
 
 
 def field_data(category, field_index, *field_values):

--- a/src/nomnom/nominate/urls.py
+++ b/src/nomnom/nominate/urls.py
@@ -7,22 +7,28 @@ app_name = "nominate"
 urlpatterns = [
     # has to come first so that the general <election_id> doesn't match
     path("login_error/", views.login_error, name="login_error"),
-    path("", views.ElectionView.as_view(), name="index"),
+    path("", views.election_list, name="index"),
     path(
         "<election_id>/",
-        views.ElectionModeView.as_view(),
+        views.election_mode_redirect,
         name="redirect",
     ),
     path(
         "<election_id>/nope/",
-        views.ClosedElectionView.as_view(),
+        views.election_closed,
         name="closed",
     ),
-    path("<election_id>/nominate/", views.NominationView.as_view(), name="nominate"),
+    # path("<election_id>/nominate/", views.NominationView.as_view(), name="nominate"),
+    path("<election_id>/nominate/", views.nominating_ballot, name="nominate"),
     path("<election_id>/vote/", views.VoteView.as_view(), name="vote"),
+    # path(
+    #     "<election_id>/edit_nominating_ballot/<member_id>",
+    #     views.AdminNominationView.as_view(),
+    #     name="edit_nominations",
+    # ),
     path(
         "<election_id>/edit_nominating_ballot/<member_id>",
-        views.AdminNominationView.as_view(),
+        views.admin_nomination_view,
         name="edit_nominations",
     ),
     path(

--- a/src/nomnom/nominate/views/__init__.py
+++ b/src/nomnom/nominate/views/__init__.py
@@ -1,7 +1,14 @@
 # ruff: noqa: F401
 from .base import access_denied, login_error
-from .election import ClosedElectionView, ElectionModeView, ElectionView
-from .nominate import AdminNominationView, NominationView
+from .election import (
+    election_closed,
+    election_list,
+    election_mode_redirect,
+)
+from .nominate import (
+    admin_nomination_view,
+    nominating_ballot,
+)
 from .vote import (
     AdminVoteView,
     CategoryResultsPrettyView,

--- a/src/nomnom/nominate/views/election.py
+++ b/src/nomnom/nominate/views/election.py
@@ -1,47 +1,47 @@
-from collections.abc import Iterable
-from typing import Any
-
-import django.contrib.auth.forms
-from django.conf import settings
-from django.shortcuts import get_object_or_404
-from django.urls import reverse
-from django.views.generic import DetailView, ListView, RedirectView
+from django.contrib.auth.decorators import login_required
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 
 from nomnom.nominate import models
 
 
-class ElectionView(ListView):
-    model = models.Election
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        if settings.NOMNOM_ALLOW_USERNAME_LOGIN_FOR_MEMBERS:
-            context["form"] = django.contrib.auth.forms.AuthenticationForm()
-
-        return context
-
-    def get_queryset(self):
-        query_set: Iterable[models.Election] = super().get_queryset()
-
-        return models.Election.enrich_with_user_data(query_set, self.request)
+@login_required
+def election_list(request: HttpRequest) -> HttpResponse:
+    elections = models.Election.enrich_with_user_data(
+        models.Election.objects.all(), request
+    )
+    return TemplateResponse(
+        request, "nominate/election_list.html", {"election_list": elections}
+    )
 
 
-class ElectionModeView(RedirectView):
-    permanent = False
-    query_string = True
+@login_required
+def election_mode_redirect(request: HttpRequest, election_id: str) -> HttpResponse:
+    election = get_object_or_404(models.Election, slug=election_id)
+    if election.user_can_nominate(request.user):
+        return redirect(
+            "election:nominate",
+            permanent=False,
+            election_id=election.slug,
+        )
 
-    def get_redirect_url(self, *args: Any, **kwargs: Any) -> str | None:
-        election = get_object_or_404(models.Election, slug=kwargs.get("election_id"))
-        if election.user_can_nominate(self.request.user):
-            return reverse("election:nominate", kwargs={"election_id": election.slug})
+    if election.user_can_vote(request.user):
+        return redirect(
+            "election:vote",
+            permanent=False,
+            election_id=election.slug,
+        )
 
-        if election.user_can_vote(self.request.user):
-            return reverse("election:vote", kwargs={"election_id": election.slug})
+    return redirect(
+        "election:closed",
+        permanent=False,
+        election_id=election.slug,
+    )
 
-        return reverse("election:closed", kwargs={"election_id": election.slug})
 
-
-class ClosedElectionView(DetailView):
-    model = models.Election
-    slug_url_kwarg = "election_id"
-    template_name_suffix = "_closed"
+def election_closed(request: HttpRequest, election_id: str) -> HttpResponse:
+    election = get_object_or_404(models.Election, slug=election_id)
+    return TemplateResponse(
+        request, "nominate/election_closed.html", {"election": election}
+    )

--- a/src/nomnom/nominate/views/nominate.py
+++ b/src/nomnom/nominate/views/nominate.py
@@ -1,189 +1,251 @@
-import functools
-from datetime import datetime
+from collections.abc import Callable
+from dataclasses import dataclass
 from itertools import groupby
 from operator import attrgetter
+from typing import TYPE_CHECKING, Any
 
 from django.contrib import messages
 from django.contrib.auth.decorators import (
     login_required,
     permission_required,
 )
+from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from ipware import get_client_ip
 from render_block import render_block_to_string
 
 from nomnom.nominate import models
+
+if TYPE_CHECKING:
+    from django_stubs_ext import _AnyUser as UserModel
+else:
+    from nomnom.nominate.admin import UserModel
+
 from nomnom.nominate.decorators import user_passes_test_or_forbidden
 from nomnom.nominate.forms import NominationForm
 from nomnom.nominate.tasks import link_nominations_to_works, send_ballot
 
-from .base import NominatorView
+
+@dataclass(frozen=True)
+class BallotFlow:
+    profile: models.NominatingMemberProfile
+    election: models.Election
+    template_name: str
+    can_nominate: bool
+    on_saved: Callable[[HttpRequest, "BallotFlow", bool], None]
 
 
-class NominationView(NominatorView):
-    template_name = "nominate/nominate.html"
-
-    def get_context_data(self, **kwargs):
-        nominations = kwargs.pop("nominations", None)
-        most_recent: datetime | None = None
-        if nominations is None:
-            if self.profile() and self.election():
-                nominations = groupby(
-                    self.profile().nomination_set.filter(
-                        category__election=self.election()
-                    ),
-                    attrgetter("category"),
-                )
-                nominations = {cat: list(noms) for cat, noms in nominations}
-                if nominations:
-                    most_recent = (
-                        self.profile()
-                        .nomination_set.filter(category__election=self.election())
-                        .latest("nomination_date")
-                    ).nomination_date
-        form = kwargs.pop("form", None)
-        if form is None:
-            form = NominationForm(
-                categories=list(self.categories()),
-                queryset=self.profile().nomination_set.filter(
-                    category__election=self.election()
-                ),
-            )
-        ctx = {
-            "form": form,
-            "nominations": nominations,
-            "most_recent": most_recent,
-        }
-        ctx.update(super().get_context_data(**kwargs))
-        return ctx
-
-    def can_nominate(self, request) -> bool:
-        return self.election().user_can_nominate(request.user)
-
-    def get_template_names(self) -> list[str]:
-        if self.can_nominate(self.request):
-            return super().get_template_names()
-
-        if self.election().nominations_have_closed():
-            return ["nominate/show_nominations.html"]
-
-        return ["nominate/election_closed.html"]
-
-    @transaction.atomic
-    def post(self, request: HttpRequest, *args, **kwargs):
-        if not self.can_nominate(request):
-            if self.election().nominations_have_closed():
-                messages.error(request, _("Nominations have closed for this election"))
-            else:
-                messages.error(
-                    request, f"You do not have nominating rights for {self.election()}"
-                )
-            return redirect("election:index")
-
-        profile = self.profile()
-        client_ip_address, _ignored = get_client_ip(request=request)
-
-        # Kind of hacky but works - the place on the page is passwed in the submit
-        category_saved = request.POST.get("save_all", None)
-        should_email = "save_and_email" in request.POST
-
-        form = NominationForm(categories=list(self.categories()), data=request.POST)
-
-        if form.is_valid():
-            # first, we clear all of the existing nominations for this user and election; they've
-            # submitted a new ballot, so we're going to start from scratch.
-            profile.nomination_set.filter(category__election=self.election()).delete()
-
-            # now, we're going to iterate through the formsets and save the nominations
-            for nomination in form.cleaned_data["nominations"]:
-                nomination.nominator = profile
-                nomination.nomination_ip_address = client_ip_address
-            nominations = models.Nomination.objects.bulk_create(
-                form.cleaned_data["nominations"]
-            )
-
-            def on_commit_callback():
-                link_nominations_to_works.delay([n.pk for n in nominations])
-                if should_email:
-                    send_ballot.delay(self.election().id, profile.id)
-                self.post_save_hook(request, did_email=should_email)
-
-            transaction.on_commit(on_commit_callback)
-
-            if request.htmx:
-                return HttpResponse(
-                    render_block_to_string(
-                        "nominate/nominate.html",
-                        "form",
-                        context=self.get_context_data(form=form),
-                        request=request,
-                    )
-                )
-            else:
-                url = reverse(
-                    "election:nominate",
-                    kwargs={"election_id": self.kwargs.get("election_id")},
-                )
-                anchor = f"#{category_saved}"
-                return redirect(f"{url}{anchor}")
-
-        else:
-            messages.warning(request, "Something wasn't quite right with your ballot")
-            if request.htmx:
-                return HttpResponse(
-                    render_block_to_string(
-                        "nominate/nominate.html",
-                        "form",
-                        context=self.get_context_data(form=form),
-                        request=request,
-                    )
-                )
-            else:
-                return self.render_to_response(self.get_context_data(form=form))
-
-    def post_save_hook(self, request: HttpRequest, did_email: bool = False) -> None:
-        message = "Your set of nominations was saved"
-        if did_email:
-            message += " and an email with your ballot will be sent to you"
-        messages.success(request, message)
+def require_profile(user: UserModel) -> models.NominatingMemberProfile:
+    try:
+        return user.convention_profile
+    except models.NominatingMemberProfile.DoesNotExist:
+        raise PermissionDenied("You do not have a nominating profile.")
 
 
-class AdminNominationView(NominationView):
-    template_name = "nominate/admin_nominate.html"
+def build_nominating_context(
+    election: models.Election,
+    profile: models.NominatingMemberProfile,
+    form: NominationForm,
+) -> dict[str, Any]:
+    nomination_groups = groupby(
+        profile.nomination_set.filter(category__election=election),
+        attrgetter("category"),
+    )
+    nominations = {cat: list(noms) for cat, noms in nomination_groups}
 
-    @method_decorator(login_required)
-    @method_decorator(user_passes_test_or_forbidden(lambda u: u.is_staff))
-    @method_decorator(permission_required("nominate.edit_ballot", raise_exception=True))
-    def dispatch(self, *args, **kwargs):
-        return super().dispatch(*args, **kwargs)
+    context: dict[str, Any] = {
+        "election": election,
+        "categories": models.Category.objects.filter(election=election),
+        "nominations": nominations,
+        "form": form,
+    }
 
-    def can_nominate(self, request) -> bool:
-        # the rules here are quite different; since the user is an admin, the only barrier is that
-        # they must have permissions to change nominations. That is gated in dispatch() so this
-        # is always `True`
-        return True
-
-    @functools.lru_cache
-    def profile(self) -> models.NominatingMemberProfile:
-        return get_object_or_404(
-            models.NominatingMemberProfile, id=self.kwargs.get("member_id")
+    if nominations:
+        context["most_recent"] = (
+            profile.nomination_set.filter(category__election=election)
+            .latest("nomination_date")
+            .nomination_date
         )
 
-    def post_save_hook(self, request: HttpRequest, did_email: bool = False) -> None:
-        if self.profile().user.email:
-            send_ballot.delay(
-                self.election().id,
-                self.profile().id,
-                message="An Admin has entered or modified your nominations. Please review your ballot if this is unexpected.",
-            )
-            messages.success(
+    return context
+
+
+def get_template_name(election: models.Election, user: UserModel) -> str:
+    can_nominate = election.user_can_nominate(user)
+
+    if can_nominate:
+        return "nominate/nominate.html"
+    elif election.nominations_have_closed():
+        return "nominate/show_nominations.html"
+    else:
+        return "nominate/election_closed.html"
+
+
+def initial_nomination_form(
+    election: models.Election,
+    profile: models.NominatingMemberProfile,
+) -> NominationForm:
+    return NominationForm(
+        categories=list(models.Category.objects.filter(election=election)),
+        queryset=profile.nomination_set.filter(category__election=election),
+    )
+
+
+def submitted_nomination_form(
+    request: HttpRequest, election: models.Election
+) -> NominationForm:
+    return NominationForm(
+        categories=list(models.Category.objects.filter(election=election)),
+        data=request.POST,
+    )
+
+
+def member_post_save_hook(
+    request: HttpRequest, flow: BallotFlow, did_email: bool = False
+) -> None:
+    message = "Your set of nominations was saved"
+    if did_email:
+        message += " and an email with your ballot will be sent to you"
+    messages.success(request, message)
+
+
+@login_required
+def nominating_ballot(request: HttpRequest, election_id: str) -> HttpResponse:
+    election = get_object_or_404(models.Election, slug=election_id)
+    profile = require_profile(request.user)
+    flow = BallotFlow(
+        profile=profile,
+        election=election,
+        template_name=get_template_name(election, request.user),
+        can_nominate=election.user_can_nominate(request.user),
+        on_saved=member_post_save_hook,
+    )
+
+    return _ballot(request, flow)
+
+
+def _ballot(request: HttpRequest, flow: BallotFlow) -> HttpResponse:
+    if request.method == "POST":
+        return _submit_ballot(request, flow)
+
+    form = initial_nomination_form(flow.election, flow.profile)
+    context = build_nominating_context(flow.election, flow.profile, form)
+    return TemplateResponse(request, flow.template_name, context)
+
+
+def _render_form_block(
+    request: HttpRequest, flow: BallotFlow, form: NominationForm
+) -> HttpResponse:
+    context = build_nominating_context(flow.election, flow.profile, form)
+    return HttpResponse(
+        render_block_to_string(
+            flow.template_name,
+            "form",
+            context=context,
+            request=request,
+        )
+    )
+
+
+@transaction.atomic
+def _submit_ballot(request: HttpRequest, flow: BallotFlow) -> HttpResponse:
+    election = flow.election
+    profile = flow.profile
+
+    if not flow.can_nominate:
+        if election.nominations_have_closed():
+            messages.error(request, _("Nominations have closed for this election"))
+        else:
+            messages.error(
                 request,
-                _(
-                    f"An email will be sent to {self.profile().user.email} with your changes to their ballot"
-                ),
+                f"You do not have nominating rights for {election}",
             )
+        return redirect("election:index")
+
+    form = submitted_nomination_form(request, election)
+
+    if not form.is_valid():
+        messages.warning(request, "Something wasn't quite right with your ballot")
+        if request.htmx:
+            return _render_form_block(request, flow, form)
+
+        context = build_nominating_context(election, profile, form)
+        return TemplateResponse(request, flow.template_name, context)
+
+    client_ip_address, _ignored = get_client_ip(request=request)
+    should_email = "save_and_email" in request.POST
+
+    # first, we clear all of the existing nominations for this user and election; they've
+    # submitted a new ballot, so we're going to start from scratch.
+    profile.nomination_set.filter(category__election=election).delete()
+
+    # now, we're going to iterate through the formsets and save the nominations
+    for nomination in form.cleaned_data["nominations"]:
+        nomination.nominator = profile
+        nomination.nomination_ip_address = client_ip_address
+    nominations = models.Nomination.objects.bulk_create(
+        form.cleaned_data["nominations"]
+    )
+
+    def on_commit_callback():
+        link_nominations_to_works.delay([n.pk for n in nominations])
+        if should_email:
+            send_ballot.delay(election.id, profile.id)
+
+        flow.on_saved(request, flow, should_email)
+
+    transaction.on_commit(on_commit_callback)
+
+    if request.htmx:
+        return _render_form_block(request, flow, form)
+
+    # Kind of hacky but works - the place on the page is passed in the submit
+    category_saved = request.POST.get("save_all", None)
+    url = reverse(
+        "election:nominate",
+        kwargs={"election_id": election.slug},
+    )
+    anchor = f"#{category_saved}"
+    return redirect(f"{url}{anchor}")
+
+
+def admin_post_save_hook(
+    request: HttpRequest, flow: BallotFlow, did_email: bool = False
+) -> None:
+    if flow.profile.user.email:
+        send_ballot.delay(
+            flow.election.id,
+            flow.profile.id,
+            message="An Admin has entered or modified your nominations. Please review your ballot if this is unexpected.",
+        )
+
+        messages.success(
+            request,
+            _(
+                f"An email will be sent to {flow.profile.user.email} with your changes to their ballot"
+            ),
+        )
+
+
+@login_required
+@user_passes_test_or_forbidden(lambda u: u.is_staff)
+@permission_required("nominate.edit_ballot", raise_exception=True)
+def admin_nomination_view(
+    request: HttpRequest, election_id: str, member_id: int
+) -> HttpResponse:
+    election = get_object_or_404(models.Election, slug=election_id)
+    profile = get_object_or_404(models.NominatingMemberProfile, id=member_id)
+    flow = BallotFlow(
+        profile=profile,
+        election=election,
+        template_name="nominate/admin_nominate.html",
+        can_nominate=True,
+        on_saved=admin_post_save_hook,
+    )
+
+    return _ballot(request, flow)


### PR DESCRIPTION
Why? Mostly because I think I largely agree with https://spookylukey.github.io/django-views-the-right-way/index.html

- election view classes replaced with simpler function-based ones
- nomination views condensed to function-based views instead of class-based