### PR TITLE
Add a footer to the packet item access page indicating how many members have accessed any item

### DIFF
--- a/src/nomnom/hugopacket/admin.py
+++ b/src/nomnom/hugopacket/admin.py
@@ -31,10 +31,18 @@ S3Metadata = TypedDict("S3Metadata", {"Size": int, "LastModified": datetime})
 
 @admin.register(models.ElectionPacket)
 class ElectionPacketAdmin(admin.ModelAdmin):
-    list_display = ["name", "election", "enabled"]
+    list_display = ["name", "election", "enabled", "distinct_viewer_count"]
     list_filter = ["enabled"]
     actions = ["create_sections_from_categories"]
     view_on_site = True
+    readonly_fields = ["distinct_viewer_count"]
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).with_distinct_viewer_count()
+
+    @admin.display(description="Distinct viewers", ordering="_distinct_viewer_count")
+    def distinct_viewer_count(self, obj) -> int:
+        return obj.distinct_viewer_count
 
     def get_urls(self) -> list[URLPattern]:
         urls = super().get_urls()
@@ -428,17 +436,22 @@ class PacketItemAccessAdmin(admin.ModelAdmin):
     has_code.boolean = True
     has_code.short_description = "Code Assigned"
 
-    def count_distinct_members(self):
-        distinct_member_query = self.model.objects.distinct(
-            "member__user__id"
-        ).order_by("member__user__id")
-        return len(distinct_member_query)
+    def count_distinct_members(self, request):
+        # Count distinct members who have accessed any packet file, using the queryset for the admin view.
+        # (this may cross packets, if there are more than one packet in the queryset)
+        return (
+            self.get_queryset(request)
+            .select_related("member__user")
+            .order_by("member__user__id")
+            .distinct("member__user__id")
+            .count()
+        )
 
     def changelist_view(self, request, extra_context={}):
         return super().changelist_view(
             request,
             extra_context={
-                "distinct_member_count": self.count_distinct_members(),
+                "distinct_member_count": self.count_distinct_members(request),
                 **(extra_context),
             },
         )

--- a/src/nomnom/hugopacket/admin.py
+++ b/src/nomnom/hugopacket/admin.py
@@ -428,6 +428,21 @@ class PacketItemAccessAdmin(admin.ModelAdmin):
     has_code.boolean = True
     has_code.short_description = "Code Assigned"
 
+    def count_distinct_members(self):
+        distinct_member_query = self.model.objects.distinct(
+            "member__user__id"
+        ).order_by("member__user__id")
+        return len(distinct_member_query)
+
+    def changelist_view(self, request, extra_context={}):
+        return super().changelist_view(
+            request,
+            extra_context={
+                "distinct_member_count": self.count_distinct_members(),
+                **(extra_context),
+            },
+        )
+
 
 class DistributionCodeImportForm(forms.Form):
     csv_file = forms.FileField(

--- a/src/nomnom/hugopacket/models.py
+++ b/src/nomnom/hugopacket/models.py
@@ -11,11 +11,27 @@ from nomnom.hugopacket.apps import PacketAccess
 from nomnom.nominate.models import NominatingMemberProfile
 
 
+class ElectionPacketQuerySet(models.QuerySet):
+    def with_distinct_viewer_count(self):
+        """Annotate each packet with its distinct viewer count.
+
+        This is the single source of truth for the counting logic; both the
+        model property and the admin list rely on it.
+        """
+        return self.annotate(
+            _distinct_viewer_count=models.Count(
+                "packetfile__member_accesses__member", distinct=True
+            )
+        )
+
+
 class ElectionPacket(models.Model):
     class Meta:
         permissions = [
             ("preview_packet", "Has early access to the packet"),
         ]
+
+    objects = ElectionPacketQuerySet.as_manager()
 
     election = models.OneToOneField(
         "nominate.Election", on_delete=models.SET_NULL, null=True
@@ -36,6 +52,23 @@ class ElectionPacket(models.Model):
             reverse("hugopacket:election_packet", args=[self.election.slug])
             if self.election
             else None
+        )
+
+    @property
+    def distinct_viewer_count(self) -> int:
+        # This reuses the annotation from the ElectionPacketQuerySet, if that's how we
+        # got here, avoiding an N+1 query for the viewer count in the case of us
+        # having >1 election packet.
+        annotated = getattr(self, "_distinct_viewer_count", None)
+        if annotated is not None:
+            return annotated
+        return (
+            type(self)
+            .objects.filter(pk=self.pk)
+            .with_distinct_viewer_count()
+            .values_list("_distinct_viewer_count", flat=True)
+            .first()
+            or 0
         )
 
     def __str__(self) -> str:

--- a/src/nomnom/hugopacket/templates/admin/hugopacket/packetitemaccess/change_list.html
+++ b/src/nomnom/hugopacket/templates/admin/hugopacket/packetitemaccess/change_list.html
@@ -1,0 +1,5 @@
+{% extends "admin/change_list.html" %}
+{% block pagination %}
+{{ block.super }}
+<p>Distinct members who have accessed any item: {{ distinct_member_count }}</p>
+{% endblock pagination %}


### PR DESCRIPTION
This seems to work in my local deployment (see screencap).  Let me know if it seems acceptable, or if you have any requests for the approach.  Thanks!

<img width="861" height="758" alt="Screenshot 2026-07-26 at 14 54 56" src="https://github.com/user-attachments/assets/67bf254f-4860-47d5-ab3d-89c388ef0595" />
