### PR TITLE
eph: count a nomination as a ballot, not an entry

### DIFF
--- a/src/nomnom/canonicalize/admin.py
+++ b/src/nomnom/canonicalize/admin.py
@@ -542,13 +542,17 @@ class BallotReportView(ReportView):
         return self.get_report_class()(self.category())
 
 
+def nominating_ballots_from_category(category: nominate.Category) -> list[Counter[str]]:
+    ballot_builder = BallotReport(category)
+    ballot_objs = [r[1:] for r in ballot_builder.get_report_rows()]
+    return [Counter(w.name for w in ballot) for ballot in ballot_objs]
+
+
 @user_passes_test(lambda u: u.is_staff, login_url="/admin/login/")
 @permission_required("nominate.report")
 def finalists(request: HttpRequest, category_id: int) -> HttpResponse:
     category = get_object_or_404(nominate.Category, pk=category_id)
-    ballot_builder = BallotReport(category)
-    ballot_objs = [r[1:] for r in ballot_builder.get_report_rows()]
-    ballots = [[w.name for w in ballot] for ballot in ballot_objs]
+    ballots = nominating_ballots_from_category(category)
 
     steps = []
 
@@ -569,7 +573,7 @@ def finalists(request: HttpRequest, category_id: int) -> HttpResponse:
     )
 
 
-def build_eph_csv(ballots: list[list[str]], finalist_count: int = 6) -> str:
+def build_eph_csv(ballots: list[Counter[str]], finalist_count: int = 6) -> str:
     """Run EPH on *ballots* and return the elimination report as a CSV string.
 
     Columns: Candidate, Final Score, Number of Ballots, Round 1 … Round N-1, Finalists.
@@ -647,11 +651,7 @@ def build_eph_csv(ballots: list[list[str]], finalist_count: int = 6) -> str:
 @permission_required("nominate.report")
 def finalists_csv(request: HttpRequest, category_id: int) -> HttpResponse:
     category = get_object_or_404(nominate.Category, pk=category_id)
-    ballot_builder = BallotReport(category)
-    ballot_objs = [r[1:] for r in ballot_builder.get_report_rows()]
-    ballots = [[w.name for w in ballot] for ballot in ballot_objs]
-
-    csv_content = build_eph_csv(ballots)
+    csv_content = build_eph_csv(nominating_ballots_from_category(category))
 
     filename = f"{category.election}-{category.id}-eph-elimination.csv"
     response = HttpResponse(csv_content, content_type="text/csv")
@@ -700,9 +700,7 @@ def sankey_data_view(request: HttpRequest, category_id: int) -> JsonResponse:
         mode = "compact"
 
     try:
-        ballot_builder = BallotReport(category)
-        ballot_objs = [r[1:] for r in ballot_builder.get_report_rows()]
-        ballots = [[w.name for w in ballot] for ballot in ballot_objs]
+        ballots = nominating_ballots_from_category(category)
 
         steps = []
 

--- a/src/nomnom/canonicalize/sankey.py
+++ b/src/nomnom/canonicalize/sankey.py
@@ -2,7 +2,7 @@
 
 from typing import Literal, TypedDict
 
-from nomnom.wsfs.rules.constitution_2023 import CountData
+from nomnom.wsfs.rules.constitution_2023 import CountData, NominatingBallots
 
 
 class SankeyNode(TypedDict):
@@ -82,7 +82,7 @@ def _build_work_nodes(
     visible_steps: list[EphStep],
     first_visible_idx: int,
     finalists: set[str],
-) -> tuple[list[SankeyNode], dict[str, int], list[set[str]]]:
+) -> tuple[list[SankeyNode], dict[str, int], NominatingBallots]:
     """Create nodes for each work at each visible step.
 
     Returns:
@@ -93,7 +93,7 @@ def _build_work_nodes(
     nodes: list[SankeyNode] = []
     node_id_to_idx: dict[str, int] = {}
     active_works: dict[str, CountData] = {}
-    active_works_by_step: list[set[str]] = []
+    active_works_by_step: NominatingBallots = []
     works_to_remove: set[str] = set()
 
     for relative_idx, (_ballots, counts, eliminations) in enumerate(visible_steps):
@@ -149,7 +149,7 @@ def _build_continuation_links(
     visible_steps: list[EphStep],
     first_visible_idx: int,
     node_id_to_idx: dict[str, int],
-    active_works_by_step: list[set[str]],
+    active_works_by_step: NominatingBallots,
 ) -> list[SankeyLink]:
     """Create links connecting the same work across consecutive steps."""
     links: list[SankeyLink] = []

--- a/src/nomnom/canonicalize/tests/test_admin.py
+++ b/src/nomnom/canonicalize/tests/test_admin.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import random
+from collections import Counter
 
 import pytest
 from django.contrib import admin
@@ -285,10 +286,10 @@ class TestFinalistsCsv:
           A=150, B=90
         """
         ballots = [
-            ["A", "B", "C"],
-            ["A", "B", "C"],
-            ["A", "B", "D"],
-            ["A"],
+            Counter(["A", "B", "C"]),
+            Counter(["A", "B", "C"]),
+            Counter(["A", "B", "D"]),
+            Counter(["A"]),
         ]
 
         csv_content = build_eph_csv(ballots, finalist_count=2)
@@ -316,3 +317,22 @@ class TestFinalistsCsv:
         assert data["C"] == ["40", "2", "40", "40"]
         # D eliminated after round 1 — no Round 2 or Finalists
         assert data["D"] == ["20", "1", "20"]
+
+    def test_number_of_ballots_counts_ballots_not_repeated_entries(self):
+        """A work written down twice on one ballot is on one ballot.
+
+        This is the nomination count that gets published, so it has to agree with
+        the count the elimination phase compares."""
+        ballots = [
+            Counter(["A", "A", "B"]),
+            Counter(["A", "B"]),
+            Counter(["B"]),
+        ]
+
+        csv_content = build_eph_csv(ballots, finalist_count=2)
+        rows = list(csv.reader(io.StringIO(csv_content)))
+        ballot_counts = {row[0]: row[2] for row in rows[1:]}
+
+        # A is named by 2 ballots, written down 3 times
+        assert ballot_counts["A"] == "2"
+        assert ballot_counts["B"] == "3"

--- a/src/nomnom/wsfs/rules/constitution_2023.py
+++ b/src/nomnom/wsfs/rules/constitution_2023.py
@@ -1,5 +1,6 @@
 import math
 from collections import Counter
+from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import groupby
 from operator import attrgetter
@@ -307,41 +308,47 @@ class CountData:
 class StepRecorder(Protocol):
     def __call__(
         self,
-        ballots: list[set[str]],
+        ballots: list[Counter[str]],
         counts: dict[str, CountData],
         eliminations: list[str],
     ) -> None: ...
 
 
 def null_recorder(
-    ballots: list[set[str]],
+    ballots: list[Counter[str]],
     counts: dict[str, CountData],
     eliminations: list[str],
 ) -> None:
     pass
 
 
-def eliminate_works(ballots: list[set[str]], eliminations: list[str]) -> list[set[str]]:
+def eliminate_works(
+    ballots: list[Counter[str]], eliminations: list[str]
+) -> list[Counter[str]]:
     eliminations_set = set(eliminations)
-    cleaned_ballots = [set(ballot) - eliminations_set for ballot in ballots]
+    cleaned_ballots = [
+        Counter({w: n for w, n in ballot.items() if w not in eliminations_set})
+        for ballot in ballots
+    ]
     return [ballot for ballot in cleaned_ballots if len(ballot) > 0]
 
 
 def eph(
-    # ballots are a flat list of work names; we assume canonicalization has occurred
-    # the ballots _will_ be mutated.
-    ballots: list[set[str]],
+    # Each ballot is one member's nominations, keyed by work with the number of times
+    # they wrote it down.
+    ballots: list[Counter[str]],
     finalist_count: int = 6,
     record_steps: StepRecorder = null_recorder,
 ):
     """Implement the EPH ballot construction algorithm."""
+    nominating = list(ballots)
 
-    while len(ballots) > 0:
-        counts = count_nominations(ballots)
+    while len(nominating) > 0:
+        counts = count_nominations(nominating)
         eliminations = nominations_for_elimination(counts)
         next_size = len(counts) - len(eliminations)
         record_steps(
-            ballots, counts, [] if next_size < finalist_count else eliminations
+            nominating, counts, [] if next_size < finalist_count else eliminations
         )
         if next_size == finalist_count:
             finalist_names = [
@@ -349,7 +356,7 @@ def eph(
             ]
             # Record a final step with only the finalists and their redistributed
             # scores, so auditors can verify the full point redistribution.
-            finalist_ballots = eliminate_works(ballots, eliminations)
+            finalist_ballots = eliminate_works(nominating, eliminations)
             finalist_counts = count_nominations(finalist_ballots)
             record_steps(finalist_ballots, finalist_counts, [])
             return finalist_names
@@ -357,10 +364,10 @@ def eph(
         if next_size < finalist_count:
             return list(counts.keys())
 
-        ballots = eliminate_works(ballots, eliminations)
+        nominating = eliminate_works(nominating, eliminations)
 
 
-def count_nominations(ballots: list[set[str]]) -> dict[str, CountData]:
+def count_nominations(ballots: Iterable[Counter[str]]) -> dict[str, CountData]:
     points_per_ballot = (
         60  # chosen because it means we don't need to deal with floating-point math.
     )
@@ -369,21 +376,15 @@ def count_nominations(ballots: list[set[str]]) -> dict[str, CountData]:
         divisor = len(ballot)
         nomination_points = points_per_ballot // divisor
 
-        works_seen = set()
-        for work in ballot:
+        for work, written_down in ballot.items():
             count = counts.get(work)
             if count is None:
-                count = CountData(
-                    nominations=1, points=nomination_points, ballot_count=1
-                )
+                count = CountData()
                 counts[work] = count
-            else:
-                count.nominations += 1
-                count.points += nomination_points
 
-                if work not in works_seen:
-                    count.ballot_count += 1
-                    works_seen.add(work)
+            count.nominations += written_down
+            count.ballot_count += 1
+            count.points += nomination_points
 
     return counts
 
@@ -441,11 +442,13 @@ def nominations_with_fewest_nominations(
     > more nominees are tied for both fewest number of nominations and lowest
     > point total, then all such nominees tied at that round shall be eliminated.
     """
-    fewest_nominations = min(counts.values(), key=attrgetter("nominations")).nominations
+    fewest_nominations = min(
+        counts.values(), key=attrgetter("ballot_count")
+    ).ballot_count
     fewest = {
         work: count
         for work, count in counts.items()
-        if count.nominations == fewest_nominations
+        if count.ballot_count == fewest_nominations
     }
 
     if len(fewest) > 1:

--- a/src/nomnom/wsfs/rules/constitution_2023.py
+++ b/src/nomnom/wsfs/rules/constitution_2023.py
@@ -1,6 +1,5 @@
 import math
 from collections import Counter
-from collections.abc import Iterable
 from dataclasses import dataclass
 from itertools import groupby
 from operator import attrgetter
@@ -24,6 +23,10 @@ logger = structlog.get_logger("constitution_2023")
 class ElectionBallots:
     candidates: list[Candidate]
     ballots: list[Ballot]
+
+
+type NominatingBallotType = Counter[str]
+type NominatingBallots = list[NominatingBallotType]
 
 
 class NoFinalists(Exception): ...
@@ -308,14 +311,14 @@ class CountData:
 class StepRecorder(Protocol):
     def __call__(
         self,
-        ballots: list[Counter[str]],
+        ballots: NominatingBallots,
         counts: dict[str, CountData],
         eliminations: list[str],
     ) -> None: ...
 
 
 def null_recorder(
-    ballots: list[Counter[str]],
+    ballots: NominatingBallots,
     counts: dict[str, CountData],
     eliminations: list[str],
 ) -> None:
@@ -323,8 +326,8 @@ def null_recorder(
 
 
 def eliminate_works(
-    ballots: list[Counter[str]], eliminations: list[str]
-) -> list[Counter[str]]:
+    ballots: NominatingBallots, eliminations: list[str]
+) -> NominatingBallots:
     eliminations_set = set(eliminations)
     cleaned_ballots = [
         Counter({w: n for w, n in ballot.items() if w not in eliminations_set})
@@ -336,7 +339,7 @@ def eliminate_works(
 def eph(
     # Each ballot is one member's nominations, keyed by work with the number of times
     # they wrote it down.
-    ballots: list[Counter[str]],
+    ballots: NominatingBallots,
     finalist_count: int = 6,
     record_steps: StepRecorder = null_recorder,
 ):
@@ -367,7 +370,7 @@ def eph(
         nominating = eliminate_works(nominating, eliminations)
 
 
-def count_nominations(ballots: Iterable[Counter[str]]) -> dict[str, CountData]:
+def count_nominations(ballots: NominatingBallots) -> dict[str, CountData]:
     points_per_ballot = (
         60  # chosen because it means we don't need to deal with floating-point math.
     )

--- a/src/nomnom/wsfs/tests/test_eph.py
+++ b/src/nomnom/wsfs/tests/test_eph.py
@@ -1,11 +1,19 @@
 import random
 import time
+from collections import Counter
+from collections.abc import Collection, Iterable
 
 import pytest
 from faker import Faker
 from rich.pretty import pprint
 
 from nomnom.wsfs.rules import constitution_2023 as eph
+
+
+def as_ballots(ballots: Iterable[Collection[str]]) -> list[Counter[str]]:
+    """The counting functions take one Counter per member; fixtures are easier to
+    read as plain sets and lists."""
+    return [Counter(ballot) for ballot in ballots]
 
 
 def log_round(ballots, counts, eliminations):
@@ -19,34 +27,37 @@ def make_works(faker):
 
 @pytest.fixture(name="ballots")
 def make_simple_ballota(works):
-    ballots: list[set[str]] = [
-        set(works[5:]),
-        set(works[5:]),
-        {works[2], works[1]},
-        {works[2], works[3]},
-        {works[2], works[0]},
-        {works[2], works[0]},
-        {works[0], works[1], works[3], works[6]},
-        {works[0], works[2], works[3], works[7]},
-        {works[1], works[3], works[4], works[8]},
-        {works[1], works[3], works[6], works[9]},
-    ]
-
-    return ballots
+    return as_ballots(
+        [
+            set(works[5:]),
+            set(works[5:]),
+            {works[2], works[1]},
+            {works[2], works[3]},
+            {works[2], works[0]},
+            {works[2], works[0]},
+            {works[0], works[1], works[3], works[6]},
+            {works[0], works[2], works[3], works[7]},
+            {works[1], works[3], works[4], works[8]},
+            {works[1], works[3], works[6], works[9]},
+        ]
+    )
 
 
 def assert_ballot_count_invariants(ballots, counts):
     assert sum(val.nominations for val in counts.values()) == sum(
-        len(ballot) for ballot in ballots
+        ballot.total() for ballot in ballots
     ), (
-        "The total number of nominations should be the sum of the number of works on each ballot."
+        "The total number of nominations should be the sum of the number of works written down on each ballot."
     )
+    assert sum(val.ballot_count for val in counts.values()) == sum(
+        len(ballot) for ballot in ballots
+    ), "The total ballot count should be the sum of the distinct works on each ballot."
     assert sum(val.points for val in counts.values()) == 60 * len(ballots), (
         "The total number of points should be 60 times the number of ballots."
     )
     all_works = set()
     for ballot in ballots:
-        all_works |= ballot
+        all_works.update(ballot)
 
     assert len(counts) == len(all_works), (
         "All works should be represented in the counts."
@@ -54,8 +65,8 @@ def assert_ballot_count_invariants(ballots, counts):
 
 
 def test_count_nominations_on_single_ballot(faker: Faker):
-    ballot = {faker.name() for _ in range(5)}
-    counts = eph.count_nominations([ballot])
+    ballots = as_ballots([{faker.name() for _ in range(5)}])
+    counts = eph.count_nominations(ballots)
 
     # the point total should be evenly split
     assert all(val.points == 12 for val in counts.values())
@@ -66,14 +77,12 @@ def test_count_nominations_on_single_ballot(faker: Faker):
     # the count should be the number of works on the single ballot
     assert len(counts) == 5
 
-    assert_ballot_count_invariants([ballot], counts)
+    assert_ballot_count_invariants(ballots, counts)
 
 
 def test_count_nominations_on_multiple_full_ballots(faker: Faker):
     ballot_1 = {faker.sentence(nb_words=5) for _ in range(5)}
     ballot_2 = {faker.sentence(nb_words=5) for _ in range(2)}
-
-    ballots = [ballot_1, ballot_2]
 
     overlaps = set(random.sample(list(ballot_1), k=3))
 
@@ -81,6 +90,7 @@ def test_count_nominations_on_multiple_full_ballots(faker: Faker):
 
     ic(ballot_1, ballot_2)
 
+    ballots = as_ballots([ballot_1, ballot_2])
     counts = eph.count_nominations(ballots)
 
     ic(counts)
@@ -92,7 +102,7 @@ def test_count_nominations_on_multiple_partial_ballots(faker: Faker):
     ballot_1 = {faker.sentence(nb_words=5) for _ in range(3)}
     ballot_2 = {faker.sentence(nb_words=5) for _ in range(2)}
 
-    ballots = [ballot_1, ballot_2]
+    ballots = as_ballots([ballot_1, ballot_2])
 
     ic(ballot_1, ballot_2)
 
@@ -108,7 +118,7 @@ def test_rank_nominations_with_fewest_points_single_ballot(faker: Faker):
 
     The 'fewest' is all of them."""
     ballot = {faker.sentence(nb_words=5) for _ in range(5)}
-    counts = eph.count_nominations([ballot])
+    counts = eph.count_nominations(as_ballots([ballot]))
 
     fewest = eph.nominations_with_fewest_points(counts)
 
@@ -124,7 +134,7 @@ def test_rank_nominations_with_fewest_points_single_outlier(faker: Faker):
     ballot_2 = {w for w in random.sample(list(ballot_1), k=4)} | {
         faker.sentence(nb_words=5)
     }
-    counts = eph.count_nominations([ballot_1, ballot_2])
+    counts = eph.count_nominations(as_ballots([ballot_1, ballot_2]))
 
     fewest = eph.nominations_with_fewest_points(counts)
 
@@ -138,7 +148,7 @@ def test_rank_nominations_with_fewest_points_single_short_ballot(faker: Faker):
 
     ballot_1 = {faker.sentence(nb_words=5) for _ in range(5)}
     ballot_2 = {w for w in random.sample(list(ballot_1), k=4)}
-    ballots = [ballot_1, ballot_2]
+    ballots = as_ballots([ballot_1, ballot_2])
     counts = eph.count_nominations(ballots)
 
     fewest = eph.nominations_with_fewest_points(counts)
@@ -200,9 +210,9 @@ def test_eph_speed_on_realistic_data(faker):
     works_count = 500
     works = [faker.sentence(nb_words=2) for _ in range(works_count)]
 
-    ballots = [
+    ballots = as_ballots(
         set(random.sample(works, k=random.randint(1, 5))) for _ in range(ballot_count)
-    ]
+    )
 
     start_time = time.monotonic()
     eph.eph(ballots, finalist_count=6)
@@ -223,7 +233,7 @@ def test_eph_first_round_counts_with_multiple_identical_nominations_on_one_ballo
     ballot_1 = {faker.sentence(nb_words=2).rstrip(".") for _ in range(5)}
     bullet = random.choice(list(ballot_1))
     ballot_2 = [bullet, bullet]
-    ballots = [ballot_1, ballot_2]
+    ballots = as_ballots([ballot_1, ballot_2])
 
     steps = []
 
@@ -240,3 +250,137 @@ def test_eph_first_round_counts_with_multiple_identical_nominations_on_one_ballo
     assert counts[bullet].ballot_count == 2, f"Expected '{bullet}' to be on 2 ballots."
 
     assert finalists == [bullet], "The bullet should be the finalist."
+
+
+def test_repeated_nomination_counts_as_one_ballot_however_the_ballots_arrive():
+    """A member entering the same work twice has still only nominated it once.
+
+    Canonicalization can merge variant spellings, so a ballot can legitimately name
+    the same work twice; that is one nominating ballot whichever ballot it's on."""
+    repeated = ["The Skiffy and Fanty Show", "The Skiffy and Fanty Show"]
+    alongside = {"The Skiffy and Fanty Show", "Octothorpe"}
+
+    for description, raw_ballots in [
+        ("repeated ballot last", [alongside, repeated]),
+        ("repeated ballot first", [repeated, alongside]),
+    ]:
+        ballots = as_ballots(raw_ballots)
+        counts = eph.count_nominations(ballots)
+        assert_ballot_count_invariants(ballots, counts)
+
+        assert counts["The Skiffy and Fanty Show"].ballot_count == 2, (
+            f"{description}: the work is on 2 ballots"
+        )
+        assert counts["The Skiffy and Fanty Show"].nominations == 3, (
+            f"{description}: the work was written down 3 times"
+        )
+
+
+def test_repeated_nomination_does_not_dilute_the_rest_of_its_ballot():
+    """A ballot always spreads its 60 points over the works it nominates.
+
+    Writing one of them down twice earns no second share."""
+    ballots = as_ballots([["Octothorpe", "Octothorpe", "Hugos There"]])
+    counts = eph.count_nominations(ballots)
+    assert_ballot_count_invariants(ballots, counts)
+
+    assert counts["Octothorpe"].points == 30
+    assert counts["Hugos There"].points == 30
+
+
+def test_repeated_nomination_does_not_underpay_a_full_ballot():
+    """A member who wrote one work down twice has nominated four works, not five.
+
+    So the other three are due a quarter each, not a fifth."""
+    ballots = as_ballots(
+        [
+            [
+                "A Meal of Thorns",
+                "A Meal of Thorns",
+                "Octothorpe",
+                "Hugos There",
+                "Hugo, Girl!",
+            ]
+        ]
+    )
+
+    counts = eph.count_nominations(ballots)
+
+    assert counts["A Meal of Thorns"].points == 15, (
+        "the duplicated work takes one share of the ballot, not two"
+    )
+    for co_nominee in ["Octothorpe", "Hugos There", "Hugo, Girl!"]:
+        assert counts[co_nominee].points == 15, (
+            f"{co_nominee} shares the ballot with 3 other works, so it is due a quarter"
+        )
+
+    assert_ballot_count_invariants(ballots, counts)
+
+
+def test_repeated_nomination_is_reported_the_same_way_in_every_round():
+    """A surviving work's nomination counts hold steady from round to round.
+
+    Eliminating other works shrinks the ballots a work shares, but never changes how
+    many ballots named it or how many times it was written down."""
+    ballots = as_ballots(
+        [
+            ["A Meal of Thorns", "A Meal of Thorns", "Hugo, Girl!"],
+            ["A Meal of Thorns", "Octothorpe"],
+            ["Hugo, Girl!"],
+            ["Hugo, Girl!"],
+        ]
+    )
+
+    steps = []
+    eph.eph(ballots, finalist_count=2, record_steps=lambda b, c, e: steps.append(c))
+
+    counted = [
+        (step["A Meal of Thorns"].nominations, step["A Meal of Thorns"].ballot_count)
+        for step in steps
+        if "A Meal of Thorns" in step
+    ]
+
+    assert len(counted) > 1, "the work should survive at least one elimination"
+    assert set(counted) == {(3, 2)}, (
+        f"expected (3 nominations, 2 ballots) in every round, got {counted}"
+    )
+
+
+def test_elimination_compares_ballots_not_times_written_down():
+    """The elimination phase eliminates the work fewest ballots nominated.
+
+    > the nominee with the fewest number of nominations shall be eliminated
+
+    A nomination is a ballot naming the work, so a work two members each wrote down
+    twice loses to a work three members each named once — even though more entries
+    mention it."""
+    # Repeated is named by 3 ballots but written down 5 times; Single is named by
+    # 4 ballots and written down 4 times. The bullet ballots keep the two filler
+    # works clear of the bottom two on points.
+    ballots = as_ballots(
+        [
+            ["Repeated", "Repeated", "Filler One"],
+            ["Repeated", "Repeated", "Filler One"],
+            ["Repeated", "Filler Two"],
+            ["Single", "Filler One"],
+            ["Single", "Filler One"],
+            ["Single", "Filler Two"],
+            ["Single", "Filler Two"],
+            ["Filler One"],
+            ["Filler Two"],
+        ]
+    )
+
+    steps = []
+    finalists = eph.eph(
+        ballots, finalist_count=3, record_steps=lambda b, c, e: steps.append((c, e))
+    )
+
+    counts, eliminations = steps[0]
+    assert (counts["Repeated"].nominations, counts["Repeated"].ballot_count) == (5, 3)
+    assert (counts["Single"].nominations, counts["Single"].ballot_count) == (4, 4)
+
+    assert eliminations == ["Repeated"], (
+        "the work on the fewest ballots should be eliminated"
+    )
+    assert "Single" in finalists


### PR DESCRIPTION
Canonicalization can merge two of a member's entries into the same work, so a ballot can legitimately name that work twice. The constitution eliminates "the nominee with the fewest number of nominations", meaning the fewest ballots naming it, but the elimination phase was comparing entries, and a ballot's 60 points were divided between its entries rather than between the works it nominated. A member who wrote one work down twice therefore handed it a double share of their points and inflated the count that decided eliminations, while short-changing the rest of their own ballot.

A ballot is now the multiset of works one member nominated, so the two figures cannot drift apart: a repeated entry adds to the number of times a work was written down and to nothing else.

- compare ballot counts, not entry counts, when selecting works to eliminate
- divide a ballot's points between the works it nominates, not its entries
- count ballots in the EPH CSV's "Number of Ballots" column
- build the ballots once, where they are loaded from the database, and have the counting functions take that shape directly instead of normalizing internally