### PR TITLE
Add a test case where the No Award runoff changes the result

### DIFF
--- a/src/nomnom/wsfs/tests/test_constitution_2023.py
+++ b/src/nomnom/wsfs/tests/test_constitution_2023.py
@@ -228,18 +228,23 @@ class TestEdgeCases:
 
         count_round, runoff_round = results.rounds
 
-        def elected(round) -> Set[Candidate]:
+        def elected(election_round) -> Set[Candidate]:
             return set(
                 cr.candidate
-                for cr in round.candidate_results
+                for cr in election_round.candidate_results
                 if cr.status == CandidateStatus.Elected
             )
 
-        def votes(round, candidate) -> float:
-            return next(
-                cr.number_of_votes
-                for cr in round.candidate_results
-                if cr.candidate == candidate
+        def votes(election_round, candidate) -> int:
+            # pyrankvote tallies in floating point, but every ballot here is a
+            # whole vote; round to int so the assertions below don't compare an
+            # int to a float.
+            return round(
+                next(
+                    cr.number_of_votes
+                    for cr in election_round.candidate_results
+                    if cr.candidate == candidate
+                )
             )
 
         # Candidate A survives the count...

--- a/src/nomnom/wsfs/tests/test_constitution_2023.py
+++ b/src/nomnom/wsfs/tests/test_constitution_2023.py
@@ -182,6 +182,76 @@ class TestEdgeCases:
                     f"Unexpected vote count for {cr.candidate}"
                 )
 
+    def test_no_award_wins_the_runoff(self):
+        """No Award can beat the winner of the count in the final runoff.
+
+        The minimal case: Candidate A survives the instant-runoff count, but a
+        majority of the voters ranked No Award above A.
+
+            Voter 1: A, No Award
+            Voter 2: A, No Award
+            Voter 3: B, No Award
+            Voter 4: C, No Award
+            Voter 5: No Award
+
+        In the count, B, C and No Award are tied for last place with one
+        first-preference vote each, so all three are eliminated together; none
+        of their ballots have a surviving preference to transfer, which leaves A
+        as the only candidate in the race and the winner of the count. In the
+        runoff, No Award is ranked above A on three of the five ballots, so no
+        award is granted in the category.
+        """
+        a = Candidate("Candidate A")
+        b = Candidate("Candidate B")
+        c = Candidate("Candidate C")
+        no_award = Candidate("No Award")
+
+        candidates = [a, b, c, no_award]
+
+        ballots = [
+            Ballot([a, no_award]),
+            Ballot([a, no_award]),
+            Ballot([b, no_award]),
+            Ballot([c, no_award]),
+            Ballot([no_award]),
+        ]
+
+        results = hugo_voting(candidates, ballots, runoff_candidate=no_award)
+
+        # debugging
+        for r in results.rounds:
+            print(r)
+
+        # One counting round (B, C and No Award are tied for last and eliminated,
+        # leaving A to fill the only seat) plus the runoff.
+        assert len(results.rounds) == 2, "Unexpected number of rounds"
+
+        count_round, runoff_round = results.rounds
+
+        def elected(round) -> Set[Candidate]:
+            return set(
+                cr.candidate
+                for cr in round.candidate_results
+                if cr.status == CandidateStatus.Elected
+            )
+
+        def votes(round, candidate) -> float:
+            return next(
+                cr.number_of_votes
+                for cr in round.candidate_results
+                if cr.candidate == candidate
+            )
+
+        # Candidate A survives the count...
+        assert elected(count_round) == {a}, "Candidate A should win the count"
+
+        # ... but loses the runoff to No Award, 3 votes to 2.
+        assert elected(runoff_round) == {no_award}, "No Award should win the runoff"
+        assert votes(runoff_round, no_award) == 3
+        assert votes(runoff_round, a) == 2
+
+        assert results.get_winners() == [no_award]
+
     def test_when_tied_for_elimination_use_first_place_votes_as_tiebreaker(self):
         """Don't eliminate all bottom candidates automatically.
 


### PR DESCRIPTION
Adds `TestEdgeCases.test_no_award_wins_the_runoff`, covering the minimal ballot set in which the final runoff against No Award overturns the instant-runoff count:

```
Voter 1: Candidate A, No Award
Voter 2: Candidate A, No Award
Voter 3: Candidate B, No Award
Voter 4: Candidate C, No Award
Voter 5: No Award
```

B, C and No Award tie for last with one first preference each and are eliminated together; no ballot has a surviving preference to transfer, so A fills the only seat with 2 votes. No Award then beats A 3–2 in the runoff.

| | Count round | Runoff round |
|---|---|---|
| Candidate A | **2 — Elected** | 2 — Rejected |
| Candidate B | 1 — Rejected | — |
| Candidate C | 1 — Rejected | — |
| No Award | 1 — Rejected | **3 — Elected** |

None of the existing cases fail if the runoff is dropped or miscounted; this one does.

Verified: 7 passed in `test_constitution_2023.py`, `ruff check` and `ruff format --check` clean. The test needs no database — it calls `hugo_voting` directly with pyrankvote objects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)